### PR TITLE
Added map and filter method to UITextField.

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -67,7 +67,9 @@
 				69491BBD1A7C217100A13B6B /* BondTests */,
 				69491BAF1A7C217100A13B6B /* Products */,
 			);
+			indentWidth = 2;
 			sourceTree = "<group>";
+			tabWidth = 2;
 		};
 		69491BAF1A7C217100A13B6B /* Products */ = {
 			isa = PBXGroup;

--- a/Bond/Bond+UIKit.swift
+++ b/Bond/Bond+UIKit.swift
@@ -283,6 +283,15 @@ extension UISwitch: Dynamical, Bondable {
 private var designatedBondHandleUITextField: UInt8 = 0;
 
 extension UITextField: Dynamical, Bondable {
+  
+  public func map<U>(f: String -> U) -> Dynamic<U> {
+    return self.designatedDynamic().map(f)
+  }
+  
+  public func filter(f: String -> Bool) -> Dynamic<String> {
+    return self.designatedDynamic().filter(f)
+  }
+  
   public func designatedDynamic() -> Dynamic<String> {
     return ControlDynamic<String, TextFieldDynamicHelper>(helper: TextFieldDynamicHelper(control: self))
   }

--- a/Bond/Bond.swift
+++ b/Bond/Bond.swift
@@ -164,7 +164,7 @@ public func filter<T>(dynamic: Dynamic<T>, f: T -> Bool) -> Dynamic<T> {
   return _filter(dynamic, f)
 }
 
-public func map<S: Dynamical, T where S.DynamicType == T>(dynamical: S, f: T -> Bool) -> Dynamic<T> {
+public func filter<S: Dynamical, T where S.DynamicType == T>(dynamical: S, f: T -> Bool) -> Dynamic<T> {
   return _filter(dynamical.designatedDynamic(), f)
 }
 
@@ -178,6 +178,14 @@ private func _filter<T>(dynamic: Dynamic<T>, f: T -> Bool) -> Dynamic<T> {
 
 // MARK: Reduce
 
+public func reduce<A: Dynamical, B: Dynamical, T>(a: A, b: B, v0: T, f: (A.DynamicType, B.DynamicType) -> T) -> Dynamic<T> {
+  return _reduce(a.designatedDynamic(), b.designatedDynamic(), v0, f)
+}
+
+public func reduce<A: Dynamical, B: Dynamical, C: Dynamical, T>(a: A, b: B, c: C, v0: T, f: (A.DynamicType, B.DynamicType, C.DynamicType) -> T) -> Dynamic<T> {
+  return _reduce(a.designatedDynamic(), b.designatedDynamic(), c.designatedDynamic(), v0, f)
+}
+
 public func reduce<A, B, T>(dA: Dynamic<A>, dB: Dynamic<B>, v0: T, f: (A, B) -> T) -> Dynamic<T> {
   return _reduce(dA, dB, v0, f)
 }
@@ -186,7 +194,7 @@ public func reduce<A, B, C, T>(dA: Dynamic<A>, dB: Dynamic<B>, dC: Dynamic<C>, v
   return _reduce(dA, dB, dC, v0, f)
 }
 
-public func _reduce<A, B, T>(dA: Dynamic<A>, dB: Dynamic<B>, v0: T, f: (A, B) -> T) -> Dynamic<T> {
+private func _reduce<A, B, T>(dA: Dynamic<A>, dB: Dynamic<B>, v0: T, f: (A, B) -> T) -> Dynamic<T> {
   let dyn = DynamicExtended<T>(v0)
   
   let bA = Bond<A> { [unowned dyn, weak dB] in
@@ -206,7 +214,7 @@ public func _reduce<A, B, T>(dA: Dynamic<A>, dB: Dynamic<B>, v0: T, f: (A, B) ->
   return dyn
 }
 
-public func _reduce<A, B, C, T>(dA: Dynamic<A>, dB: Dynamic<B>, dC: Dynamic<C>, v0: T, f: (A, B, C) -> T) -> Dynamic<T> {
+private func _reduce<A, B, C, T>(dA: Dynamic<A>, dB: Dynamic<B>, dC: Dynamic<C>, v0: T, f: (A, B, C) -> T) -> Dynamic<T> {
   let dyn = DynamicExtended<T>(v0)
   
   let bA = Bond<A> { [unowned dyn, weak dB, weak dC] in


### PR DESCRIPTION
I wrote like this as you told in README. 
However, `map` function says an error `'UITextField' does not have a member named 'map'`.

```swift
class ViewController: UIViewController {
    
    @IBOutlet weak private var textField: UITextField!
    @IBOutlet weak private var label: UILabel!

    override func viewDidLoad() {
       super.viewDidLoad()
       textField ->> label // OK
       textField.map { "Hi " + $0 } ->> label // NG: 'UITextField' does not have a member named 'map'
       textField.designatedDynamic().map { "Hi" + $0 } ->> label // OK
    }
```

I think you need to implement `map` and `filter` function to Bond+UIKit.swift.
So, I implemented to `map` and `filter` function to UITextField extenstion, and also `reduce` function in Bond.swift.