### PR TITLE
Add UIKit tests

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -24,6 +24,7 @@
 		03ACB5081AB555D6001B3E64 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB5061AB555D6001B3E64 /* Main.storyboard */; };
 		03ACB50A1AB555D6001B3E64 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB5091AB555D6001B3E64 /* Images.xcassets */; };
 		03ACB50D1AB555D6001B3E64 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB50B1AB555D6001B3E64 /* LaunchScreen.xib */; };
+		03ACB5231AB6C840001B3E64 /* AssertEqualForOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ACB5221AB6C840001B3E64 /* AssertEqualForOptionals.swift */; };
 		69491BB41A7C217100A13B6B /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 69491BB31A7C217100A13B6B /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69491BBA1A7C217100A13B6B /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
 		69491BC11A7C217100A13B6B /* BondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BC01A7C217100A13B6B /* BondTests.swift */; };
@@ -108,6 +109,7 @@
 		03ACB50C1AB555D6001B3E64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
 		03ACB5171AB555D6001B3E64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		03ACB5181AB555D6001B3E64 /* iOSAppForTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSAppForTestingTests.swift; sourceTree = "<group>"; };
+		03ACB5221AB6C840001B3E64 /* AssertEqualForOptionals.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AssertEqualForOptionals.swift; sourceTree = "<group>"; };
 		69491BAE1A7C217100A13B6B /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		69491BB21A7C217100A13B6B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		69491BB31A7C217100A13B6B /* Bond.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bond.h; sourceTree = "<group>"; };
@@ -299,6 +301,7 @@
 				EC6A5A841AB31954006071B6 /* ArrayTests.swift */,
 				03A5DC961AAF9612007616B4 /* UIKit */,
 				69491BBE1A7C217100A13B6B /* Supporting Files */,
+				03ACB5221AB6C840001B3E64 /* AssertEqualForOptionals.swift */,
 			);
 			path = BondTests;
 			sourceTree = "<group>";
@@ -575,6 +578,7 @@
 			files = (
 				03A5DCA01AAF982D007616B4 /* UIImageViewTests.swift in Sources */,
 				03A5DCA21AAF9893007616B4 /* UIBarItemTests.swift in Sources */,
+				03ACB5231AB6C840001B3E64 /* AssertEqualForOptionals.swift in Sources */,
 				69491BC11A7C217100A13B6B /* BondTests.swift in Sources */,
 				EC6A5A851AB31954006071B6 /* ArrayTests.swift in Sources */,
 				69491BD31A7C242900A13B6B /* DynamicTests.swift in Sources */,

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -19,6 +19,11 @@
 		03A5DCA81AAF995F007616B4 /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA71AAF995F007616B4 /* UITextFieldTests.swift */; };
 		03A5DCAA1AAF99C2007616B4 /* UITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA91AAF99C2007616B4 /* UITextViewTests.swift */; };
 		03A5DCAE1AAF9C3F007616B4 /* UIDatePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCAD1AAF9C3F007616B4 /* UIDatePickerTests.swift */; };
+		03ACB5031AB555D6001B3E64 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ACB5021AB555D6001B3E64 /* AppDelegate.swift */; };
+		03ACB5051AB555D6001B3E64 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ACB5041AB555D6001B3E64 /* ViewController.swift */; };
+		03ACB5081AB555D6001B3E64 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB5061AB555D6001B3E64 /* Main.storyboard */; };
+		03ACB50A1AB555D6001B3E64 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB5091AB555D6001B3E64 /* Images.xcassets */; };
+		03ACB50D1AB555D6001B3E64 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB50B1AB555D6001B3E64 /* LaunchScreen.xib */; };
 		69491BB41A7C217100A13B6B /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 69491BB31A7C217100A13B6B /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69491BBA1A7C217100A13B6B /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
 		69491BC11A7C217100A13B6B /* BondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BC01A7C217100A13B6B /* BondTests.swift */; };
@@ -58,6 +63,13 @@
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
+		03ACB5201AB555EF001B3E64 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 69491BA51A7C217100A13B6B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = 03ACB4FD1AB555D6001B3E64;
+			remoteInfo = iOSAppForTesting;
+		};
 		69491BBB1A7C217100A13B6B /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
 			containerPortal = 69491BA51A7C217100A13B6B /* Project object */;
@@ -87,6 +99,15 @@
 		03A5DCA71AAF995F007616B4 /* UITextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextFieldTests.swift; sourceTree = "<group>"; };
 		03A5DCA91AAF99C2007616B4 /* UITextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewTests.swift; sourceTree = "<group>"; };
 		03A5DCAD1AAF9C3F007616B4 /* UIDatePickerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIDatePickerTests.swift; sourceTree = "<group>"; };
+		03ACB4FE1AB555D6001B3E64 /* iOSAppForTesting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = iOSAppForTesting.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		03ACB5011AB555D6001B3E64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03ACB5021AB555D6001B3E64 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		03ACB5041AB555D6001B3E64 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		03ACB5071AB555D6001B3E64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		03ACB5091AB555D6001B3E64 /* Images.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Images.xcassets; sourceTree = "<group>"; };
+		03ACB50C1AB555D6001B3E64 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.xib; name = Base; path = Base.lproj/LaunchScreen.xib; sourceTree = "<group>"; };
+		03ACB5171AB555D6001B3E64 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		03ACB5181AB555D6001B3E64 /* iOSAppForTestingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = iOSAppForTestingTests.swift; sourceTree = "<group>"; };
 		69491BAE1A7C217100A13B6B /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		69491BB21A7C217100A13B6B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		69491BB31A7C217100A13B6B /* Bond.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bond.h; sourceTree = "<group>"; };
@@ -123,6 +144,13 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		03ACB4FB1AB555D6001B3E64 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		69491BAA1A7C217100A13B6B /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -175,6 +203,44 @@
 			name = UIKit;
 			sourceTree = "<group>";
 		};
+		03ACB4FF1AB555D6001B3E64 /* iOSAppForTesting */ = {
+			isa = PBXGroup;
+			children = (
+				03ACB5021AB555D6001B3E64 /* AppDelegate.swift */,
+				03ACB5041AB555D6001B3E64 /* ViewController.swift */,
+				03ACB5061AB555D6001B3E64 /* Main.storyboard */,
+				03ACB5091AB555D6001B3E64 /* Images.xcassets */,
+				03ACB50B1AB555D6001B3E64 /* LaunchScreen.xib */,
+				03ACB5001AB555D6001B3E64 /* Supporting Files */,
+			);
+			path = iOSAppForTesting;
+			sourceTree = "<group>";
+		};
+		03ACB5001AB555D6001B3E64 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				03ACB5011AB555D6001B3E64 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		03ACB5151AB555D6001B3E64 /* iOSAppForTestingTests */ = {
+			isa = PBXGroup;
+			children = (
+				03ACB5181AB555D6001B3E64 /* iOSAppForTestingTests.swift */,
+				03ACB5161AB555D6001B3E64 /* Supporting Files */,
+			);
+			path = iOSAppForTestingTests;
+			sourceTree = "<group>";
+		};
+		03ACB5161AB555D6001B3E64 /* Supporting Files */ = {
+			isa = PBXGroup;
+			children = (
+				03ACB5171AB555D6001B3E64 /* Info.plist */,
+			);
+			name = "Supporting Files";
+			sourceTree = "<group>";
+		};
 		69491BA41A7C217100A13B6B = {
 			isa = PBXGroup;
 			children = (
@@ -182,6 +248,8 @@
 				ECD653A41A9B6B770038A9AC /* README.md */,
 				69491BB01A7C217100A13B6B /* Bond */,
 				69491BBD1A7C217100A13B6B /* BondTests */,
+				03ACB4FF1AB555D6001B3E64 /* iOSAppForTesting */,
+				03ACB5151AB555D6001B3E64 /* iOSAppForTestingTests */,
 				69491BAF1A7C217100A13B6B /* Products */,
 			);
 			sourceTree = "<group>";
@@ -193,6 +261,7 @@
 				69491BB91A7C217100A13B6B /* BondTests.xctest */,
 				DCA979691A83C3A100DD4A30 /* Bond.framework */,
 				DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */,
+				03ACB4FE1AB555D6001B3E64 /* iOSAppForTesting.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -284,6 +353,23 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		03ACB4FD1AB555D6001B3E64 /* iOSAppForTesting */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 03ACB51E1AB555D6001B3E64 /* Build configuration list for PBXNativeTarget "iOSAppForTesting" */;
+			buildPhases = (
+				03ACB4FA1AB555D6001B3E64 /* Sources */,
+				03ACB4FB1AB555D6001B3E64 /* Frameworks */,
+				03ACB4FC1AB555D6001B3E64 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = iOSAppForTesting;
+			productName = iOSAppForTesting;
+			productReference = 03ACB4FE1AB555D6001B3E64 /* iOSAppForTesting.app */;
+			productType = "com.apple.product-type.application";
+		};
 		69491BAD1A7C217100A13B6B /* Bond */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 69491BC41A7C217100A13B6B /* Build configuration list for PBXNativeTarget "Bond" */;
@@ -314,6 +400,7 @@
 			);
 			dependencies = (
 				69491BBC1A7C217100A13B6B /* PBXTargetDependency */,
+				03ACB5211AB555EF001B3E64 /* PBXTargetDependency */,
 			);
 			name = BondTests;
 			productName = BondTests;
@@ -365,11 +452,15 @@
 				LastUpgradeCheck = 0610;
 				ORGANIZATIONNAME = Bond;
 				TargetAttributes = {
+					03ACB4FD1AB555D6001B3E64 = {
+						CreatedOnToolsVersion = 6.1.1;
+					};
 					69491BAD1A7C217100A13B6B = {
 						CreatedOnToolsVersion = 6.1.1;
 					};
 					69491BB81A7C217100A13B6B = {
 						CreatedOnToolsVersion = 6.1.1;
+						TestTargetID = 03ACB4FD1AB555D6001B3E64;
 					};
 					DCA979681A83C3A100DD4A30 = {
 						CreatedOnToolsVersion = 6.2;
@@ -385,6 +476,7 @@
 			hasScannedForEncodings = 0;
 			knownRegions = (
 				en,
+				Base,
 			);
 			mainGroup = 69491BA41A7C217100A13B6B;
 			productRefGroup = 69491BAF1A7C217100A13B6B /* Products */;
@@ -395,11 +487,22 @@
 				69491BB81A7C217100A13B6B /* BondTests */,
 				DCA979681A83C3A100DD4A30 /* BondOSX */,
 				DCA979721A83C3A200DD4A30 /* BondOSXTests */,
+				03ACB4FD1AB555D6001B3E64 /* iOSAppForTesting */,
 			);
 		};
 /* End PBXProject section */
 
 /* Begin PBXResourcesBuildPhase section */
+		03ACB4FC1AB555D6001B3E64 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03ACB5081AB555D6001B3E64 /* Main.storyboard in Resources */,
+				03ACB50D1AB555D6001B3E64 /* LaunchScreen.xib in Resources */,
+				03ACB50A1AB555D6001B3E64 /* Images.xcassets in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		69491BAC1A7C217100A13B6B /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -431,6 +534,15 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		03ACB4FA1AB555D6001B3E64 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				03ACB5051AB555D6001B3E64 /* ViewController.swift in Sources */,
+				03ACB5031AB555D6001B3E64 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		69491BA91A7C217100A13B6B /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -507,6 +619,11 @@
 /* End PBXSourcesBuildPhase section */
 
 /* Begin PBXTargetDependency section */
+		03ACB5211AB555EF001B3E64 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = 03ACB4FD1AB555D6001B3E64 /* iOSAppForTesting */;
+			targetProxy = 03ACB5201AB555EF001B3E64 /* PBXContainerItemProxy */;
+		};
 		69491BBC1A7C217100A13B6B /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
 			target = 69491BAD1A7C217100A13B6B /* Bond */;
@@ -519,7 +636,50 @@
 		};
 /* End PBXTargetDependency section */
 
+/* Begin PBXVariantGroup section */
+		03ACB5061AB555D6001B3E64 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				03ACB5071AB555D6001B3E64 /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		03ACB50B1AB555D6001B3E64 /* LaunchScreen.xib */ = {
+			isa = PBXVariantGroup;
+			children = (
+				03ACB50C1AB555D6001B3E64 /* Base */,
+			);
+			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
 /* Begin XCBuildConfiguration section */
+		03ACB51A1AB555D6001B3E64 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				INFOPLIST_FILE = iOSAppForTesting/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Debug;
+		};
+		03ACB51B1AB555D6001B3E64 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				INFOPLIST_FILE = iOSAppForTesting/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_NAME = "$(TARGET_NAME)";
+			};
+			name = Release;
+		};
 		69491BC21A7C217100A13B6B /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -649,6 +809,7 @@
 				INFOPLIST_FILE = BondTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSAppForTesting.app/iOSAppForTesting";
 			};
 			name = Debug;
 		};
@@ -662,6 +823,7 @@
 				INFOPLIST_FILE = BondTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOSAppForTesting.app/iOSAppForTesting";
 			};
 			name = Release;
 		};
@@ -744,6 +906,14 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		03ACB51E1AB555D6001B3E64 /* Build configuration list for PBXNativeTarget "iOSAppForTesting" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				03ACB51A1AB555D6001B3E64 /* Debug */,
+				03ACB51B1AB555D6001B3E64 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
 		69491BA81A7C217100A13B6B /* Build configuration list for PBXProject "Bond" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -7,6 +7,18 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		03A5DC951AAF95EB007616B4 /* UIButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC941AAF95EB007616B4 /* UIButtonTests.swift */; };
+		03A5DC981AAF96AD007616B4 /* UISliderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC971AAF96AD007616B4 /* UISliderTests.swift */; };
+		03A5DC9A1AAF971F007616B4 /* UIViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC991AAF971F007616B4 /* UIViewTests.swift */; };
+		03A5DC9C1AAF977F007616B4 /* UILabelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC9B1AAF977F007616B4 /* UILabelTests.swift */; };
+		03A5DC9E1AAF97E9007616B4 /* UIProgressViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC9D1AAF97E9007616B4 /* UIProgressViewTests.swift */; };
+		03A5DCA01AAF982D007616B4 /* UIImageViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DC9F1AAF982D007616B4 /* UIImageViewTests.swift */; };
+		03A5DCA21AAF9893007616B4 /* UIBarItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA11AAF9893007616B4 /* UIBarItemTests.swift */; };
+		03A5DCA41AAF98DA007616B4 /* UIActivityIndicatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA31AAF98DA007616B4 /* UIActivityIndicatorTests.swift */; };
+		03A5DCA61AAF992F007616B4 /* UISwitchTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA51AAF992F007616B4 /* UISwitchTests.swift */; };
+		03A5DCA81AAF995F007616B4 /* UITextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA71AAF995F007616B4 /* UITextFieldTests.swift */; };
+		03A5DCAA1AAF99C2007616B4 /* UITextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCA91AAF99C2007616B4 /* UITextViewTests.swift */; };
+		03A5DCAE1AAF9C3F007616B4 /* UIDatePickerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03A5DCAD1AAF9C3F007616B4 /* UIDatePickerTests.swift */; };
 		69491BB41A7C217100A13B6B /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 69491BB31A7C217100A13B6B /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69491BBA1A7C217100A13B6B /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
 		69491BC11A7C217100A13B6B /* BondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BC01A7C217100A13B6B /* BondTests.swift */; };
@@ -28,8 +40,6 @@
 		EC7137E21AA239FC00CFC854 /* Bond+Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC048D141AA2386A00E9794C /* Bond+Functional.swift */; };
 		EC7137E31AA239FD00CFC854 /* Bond+Functional.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC048D141AA2386A00E9794C /* Bond+Functional.swift */; };
 		EC7137E41AA25E9300CFC854 /* FunctionalTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECD653A51A9B6BF30038A9AC /* FunctionalTests.swift */; };
-		EC7137E51AA26F0800CFC854 /* UIKitDynamicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC71C0AB1A9F839A009FEA4B /* UIKitDynamicTests.swift */; };
-		EC74CFD21A8BF1A300ED4026 /* UIKitBondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC74CFD11A8BF1A300ED4026 /* UIKitBondTests.swift */; };
 		EC847EB01AA7963F002971B8 /* Bond+Foundation.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BCC1A7C21B600A13B6B /* Bond+Foundation.swift */; };
 		EC847EB11AA796F5002971B8 /* FoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC867F891AA73AD5007B4BC4 /* FoundationTests.swift */; };
 		EC847EB21AA796F8002971B8 /* FoundationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC867F891AA73AD5007B4BC4 /* FoundationTests.swift */; };
@@ -65,6 +75,18 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		03A5DC941AAF95EB007616B4 /* UIButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIButtonTests.swift; sourceTree = "<group>"; };
+		03A5DC971AAF96AD007616B4 /* UISliderTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISliderTests.swift; sourceTree = "<group>"; };
+		03A5DC991AAF971F007616B4 /* UIViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIViewTests.swift; sourceTree = "<group>"; };
+		03A5DC9B1AAF977F007616B4 /* UILabelTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UILabelTests.swift; sourceTree = "<group>"; };
+		03A5DC9D1AAF97E9007616B4 /* UIProgressViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIProgressViewTests.swift; sourceTree = "<group>"; };
+		03A5DC9F1AAF982D007616B4 /* UIImageViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIImageViewTests.swift; sourceTree = "<group>"; };
+		03A5DCA11AAF9893007616B4 /* UIBarItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIBarItemTests.swift; sourceTree = "<group>"; };
+		03A5DCA31AAF98DA007616B4 /* UIActivityIndicatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIActivityIndicatorTests.swift; sourceTree = "<group>"; };
+		03A5DCA51AAF992F007616B4 /* UISwitchTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UISwitchTests.swift; sourceTree = "<group>"; };
+		03A5DCA71AAF995F007616B4 /* UITextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextFieldTests.swift; sourceTree = "<group>"; };
+		03A5DCA91AAF99C2007616B4 /* UITextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITextViewTests.swift; sourceTree = "<group>"; };
+		03A5DCAD1AAF9C3F007616B4 /* UIDatePickerTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIDatePickerTests.swift; sourceTree = "<group>"; };
 		69491BAE1A7C217100A13B6B /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		69491BB21A7C217100A13B6B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		69491BB31A7C217100A13B6B /* Bond.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = Bond.h; sourceTree = "<group>"; };
@@ -82,8 +104,6 @@
 		EC048D171AA238AF00E9794C /* Bond+Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+Operators.swift"; sourceTree = "<group>"; };
 		EC0F22F51AA353100051723D /* Bond+UIActivityIndicatorView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+UIActivityIndicatorView.swift"; sourceTree = "<group>"; };
 		EC6A5A841AB31954006071B6 /* ArrayTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ArrayTests.swift; sourceTree = "<group>"; };
-		EC71C0AB1A9F839A009FEA4B /* UIKitDynamicTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitDynamicTests.swift; sourceTree = "<group>"; };
-		EC74CFD11A8BF1A300ED4026 /* UIKitBondTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UIKitBondTests.swift; sourceTree = "<group>"; };
 		EC867F891AA73AD5007B4BC4 /* FoundationTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = FoundationTests.swift; sourceTree = "<group>"; };
 		ECD653A21A9B6B6B0038A9AC /* Bond.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; path = Bond.podspec; sourceTree = "<group>"; };
 		ECD653A41A9B6B770038A9AC /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -136,6 +156,25 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		03A5DC961AAF9612007616B4 /* UIKit */ = {
+			isa = PBXGroup;
+			children = (
+				03A5DC991AAF971F007616B4 /* UIViewTests.swift */,
+				03A5DC9F1AAF982D007616B4 /* UIImageViewTests.swift */,
+				03A5DC9D1AAF97E9007616B4 /* UIProgressViewTests.swift */,
+				03A5DCA11AAF9893007616B4 /* UIBarItemTests.swift */,
+				03A5DC9B1AAF977F007616B4 /* UILabelTests.swift */,
+				03A5DC971AAF96AD007616B4 /* UISliderTests.swift */,
+				03A5DC941AAF95EB007616B4 /* UIButtonTests.swift */,
+				03A5DCA51AAF992F007616B4 /* UISwitchTests.swift */,
+				03A5DCA71AAF995F007616B4 /* UITextFieldTests.swift */,
+				03A5DCA91AAF99C2007616B4 /* UITextViewTests.swift */,
+				03A5DCAD1AAF9C3F007616B4 /* UIDatePickerTests.swift */,
+				03A5DCA31AAF98DA007616B4 /* UIActivityIndicatorTests.swift */,
+			);
+			name = UIKit;
+			sourceTree = "<group>";
+		};
 		69491BA41A7C217100A13B6B = {
 			isa = PBXGroup;
 			children = (
@@ -186,11 +225,10 @@
 			children = (
 				69491BC01A7C217100A13B6B /* BondTests.swift */,
 				69491BD21A7C242900A13B6B /* DynamicTests.swift */,
-				EC74CFD11A8BF1A300ED4026 /* UIKitBondTests.swift */,
-				EC71C0AB1A9F839A009FEA4B /* UIKitDynamicTests.swift */,
 				ECD653A51A9B6BF30038A9AC /* FunctionalTests.swift */,
 				EC867F891AA73AD5007B4BC4 /* FoundationTests.swift */,
 				EC6A5A841AB31954006071B6 /* ArrayTests.swift */,
+				03A5DC961AAF9612007616B4 /* UIKit */,
 				69491BBE1A7C217100A13B6B /* Supporting Files */,
 			);
 			path = BondTests;
@@ -423,12 +461,22 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				03A5DCA01AAF982D007616B4 /* UIImageViewTests.swift in Sources */,
+				03A5DCA21AAF9893007616B4 /* UIBarItemTests.swift in Sources */,
 				69491BC11A7C217100A13B6B /* BondTests.swift in Sources */,
 				EC6A5A851AB31954006071B6 /* ArrayTests.swift in Sources */,
 				69491BD31A7C242900A13B6B /* DynamicTests.swift in Sources */,
+				03A5DC9A1AAF971F007616B4 /* UIViewTests.swift in Sources */,
+				03A5DC981AAF96AD007616B4 /* UISliderTests.swift in Sources */,
+				03A5DCA41AAF98DA007616B4 /* UIActivityIndicatorTests.swift in Sources */,
+				03A5DC951AAF95EB007616B4 /* UIButtonTests.swift in Sources */,
 				EC847EB11AA796F5002971B8 /* FoundationTests.swift in Sources */,
-				EC74CFD21A8BF1A300ED4026 /* UIKitBondTests.swift in Sources */,
-				EC7137E51AA26F0800CFC854 /* UIKitDynamicTests.swift in Sources */,
+				03A5DCAE1AAF9C3F007616B4 /* UIDatePickerTests.swift in Sources */,
+				03A5DC9C1AAF977F007616B4 /* UILabelTests.swift in Sources */,
+				03A5DCAA1AAF99C2007616B4 /* UITextViewTests.swift in Sources */,
+				03A5DCA81AAF995F007616B4 /* UITextFieldTests.swift in Sources */,
+				03A5DCA61AAF992F007616B4 /* UISwitchTests.swift in Sources */,
+				03A5DC9E1AAF97E9007616B4 /* UIProgressViewTests.swift in Sources */,
 				EC7137E41AA25E9300CFC854 /* FunctionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BondTests/AssertEqualForOptionals.swift
+++ b/BondTests/AssertEqualForOptionals.swift
@@ -1,0 +1,20 @@
+//
+//  AssertEqualsForOptionals.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 15/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import Foundation
+import XCTest
+
+func XCTAssertEqual<T:Equatable>(actual: T?, expected: T?, _ message: String = "", file: String = __FILE__, line: UInt = __LINE__) {
+  switch (actual, expected) {
+  case (nil, nil): break
+  case (nil, _): XCTFail("(\"nil\") is not equal to (\"\(expected)\")", file: file, line: line)
+  case (_, nil): XCTFail("(\"\(actual)\") is not equal to (\"nil\")", file: file, line: line)
+  default: XCTAssertEqual(actual!, expected!, message, file: file, line: line)
+  }
+}
+

--- a/BondTests/UIActivityIndicatorTests.swift
+++ b/BondTests/UIActivityIndicatorTests.swift
@@ -1,0 +1,28 @@
+//
+//  UIActivityIndicatorTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIActivityIndicatorTests: XCTestCase {
+
+  func testUIActivityIndicatorViewHiddenBond() {
+    var dynamicDriver = Dynamic<Bool>(false)
+    let view = UIActivityIndicatorView()
+    
+    view.startAnimating()
+    XCTAssert(view.isAnimating() == true, "Initial value")
+    
+    dynamicDriver ->> view.dynIsAnimating
+    XCTAssert(view.isAnimating() == false, "Value after binding")
+    
+    dynamicDriver.value = true
+    XCTAssert(view.isAnimating() == true, "Value after dynamic change")
+  }
+}

--- a/BondTests/UIBarItemTests.swift
+++ b/BondTests/UIBarItemTests.swift
@@ -1,0 +1,58 @@
+//
+//  UIBarItemTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIBarItemTests: XCTestCase {
+
+  func testUIBarItemEnabledBond() {
+    var dynamicDriver = Dynamic<Bool>(false)
+    let barItem = UIBarButtonItem()
+    
+    barItem.enabled = true
+    XCTAssert(barItem.enabled == true, "Initial value")
+    
+    dynamicDriver ->> barItem.designatedBond
+    XCTAssert(barItem.enabled == false, "Value after binding")
+    
+    dynamicDriver.value = true
+    XCTAssert(barItem.enabled == true, "Value after dynamic change")
+  }
+  
+  func testUIBarItemTitleBond() {
+    var dynamicDriver = Dynamic<String>("b")
+    let barItem = UIBarButtonItem()
+    
+    barItem.title = "a"
+    XCTAssert(barItem.title == "a", "Initial value")
+    
+    dynamicDriver ->> barItem.dynTitle
+    XCTAssert(barItem.title == "b", "Value after binding")
+    
+    dynamicDriver.value = "c"
+    XCTAssert(barItem.title == "c", "Value after dynamic change")
+  }
+  
+  func testUIBarItemImageBond() {
+    let image1 = UIImage()
+    let image2 = UIImage()
+    var dynamicDriver = Dynamic<UIImage?>(nil)
+    let barItem = UIBarButtonItem()
+    
+    barItem.image = image1
+    XCTAssert(barItem.image == image1, "Initial value")
+    
+    dynamicDriver ->> barItem.dynImage
+    XCTAssert(barItem.image == nil, "Value after binding")
+    
+    dynamicDriver.value = image2
+    XCTAssert(barItem.image == image2, "Value after dynamic change")
+  }
+}

--- a/BondTests/UIButtonTests.swift
+++ b/BondTests/UIButtonTests.swift
@@ -67,10 +67,10 @@ class UIButtonTests: XCTestCase {
     button.dynEvent.filter(==, .TouchUpInside) ->> bond
     XCTAssert(observedValue == UIControlEvents.AllEvents, "Value after binding should not be changed")
     
-    button.dynEvent.value = UIControlEvents.TouchDragInside
+    button.sendActionsForControlEvents(.TouchDragInside)
     XCTAssert(observedValue == UIControlEvents.AllEvents, "Dynamic change does not pass test - should not update observedValue")
     
-    button.dynEvent.value = UIControlEvents.TouchUpInside
+    button.sendActionsForControlEvents(.TouchUpInside)
     XCTAssert(observedValue == UIControlEvents.TouchUpInside, "Dynamic change passes test - should update observedValue")
   }
 }

--- a/BondTests/UIButtonTests.swift
+++ b/BondTests/UIButtonTests.swift
@@ -1,0 +1,76 @@
+//
+//  UIButtonTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIButtonTests: XCTestCase {
+
+  func testUIButtonEnabledBond() {
+    var dynamicDriver = Dynamic<Bool>(false)
+    let button = UIButton()
+    
+    button.enabled = true
+    XCTAssert(button.enabled == true, "Initial value")
+    
+    dynamicDriver ->> button.designatedBond
+    XCTAssert(button.enabled == false, "Value after binding")
+    
+    dynamicDriver.value = true
+    XCTAssert(button.enabled == true, "Value after dynamic change")
+  }
+  
+  func testUIButtonTitleBond() {
+    var dynamicDriver = Dynamic<String>("b")
+    let button = UIButton()
+    
+    button.titleLabel?.text = "a"
+    XCTAssert(button.titleLabel?.text == "a", "Initial value")
+    
+    dynamicDriver ->> button.dynTitle
+    XCTAssert(button.titleLabel?.text == "b", "Value after binding")
+    
+    dynamicDriver.value = "c"
+    XCTAssert(button.titleLabel?.text == "c", "Value after dynamic change")
+  }
+  
+  func testUIButtonImageBond() {
+    let image1 = UIImage()
+    let image2 = UIImage()
+    var dynamicDriver = Dynamic<UIImage?>(nil)
+    let button = UIButton()
+    
+    button.setImage(image1, forState: .Normal)
+    XCTAssert(button.imageForState(.Normal) == image1, "Initial value")
+    
+    dynamicDriver ->> button.dynImageForNormalState
+    XCTAssert(button.imageForState(.Normal) == nil, "Value after binding")
+    
+    dynamicDriver.value = image2
+    XCTAssert(button.imageForState(.Normal) == image2, "Value after dynamic change")
+  }
+  
+  func testUIButtonDynamic() {
+    let button = UIButton()
+    
+    var observedValue = UIControlEvents.AllEvents
+    let bond = Bond<UIControlEvents>() { v in observedValue = v }
+    
+    XCTAssert(button.dynEvent.faulty == true, "Should be faulty initially")
+    
+    button.dynEvent.filter(==, .TouchUpInside) ->> bond
+    XCTAssert(observedValue == UIControlEvents.AllEvents, "Value after binding should not be changed")
+    
+    button.dynEvent.value = UIControlEvents.TouchDragInside
+    XCTAssert(observedValue == UIControlEvents.AllEvents, "Dynamic change does not pass test - should not update observedValue")
+    
+    button.dynEvent.value = UIControlEvents.TouchUpInside
+    XCTAssert(observedValue == UIControlEvents.TouchUpInside, "Dynamic change passes test - should update observedValue")
+  }
+}

--- a/BondTests/UIDatePickerTests.swift
+++ b/BondTests/UIDatePickerTests.swift
@@ -32,4 +32,61 @@ class UIDatePickerTests: XCTestCase {
         datePicker.dynDate.value = date2 // ideally we should simulate user input
         XCTAssert(dynamicDriver.value == date2, "Dynamic value reflects DatePicker value change")
   }
+  
+  func testOneWayOperators() {
+    let date1 = NSDate(timeIntervalSince1970: 1)
+    let date2 = NSDate(timeIntervalSince1970: 2)
+    let date3 = NSDate(timeIntervalSince1970: 3)
+    
+    var bondedValue = date1
+    let bond = Bond { bondedValue = $0 }
+    let dynamicDriver = Dynamic<NSDate>(date2)
+    let datePicker1 = UIDatePicker()
+    let datePicker2 = UIDatePicker()
+    
+    XCTAssertEqual(bondedValue, date1, "Intial value")
+    
+    dynamicDriver ->> datePicker1
+    datePicker1 ->> datePicker2
+    datePicker2 ->> bond
+    
+    XCTAssertEqual(bondedValue, date2, "Value after binding")
+    
+    dynamicDriver.value = date3
+    
+    XCTAssertEqual(bondedValue, date3, "Value after dynamic update")
+  }
+  
+  func testTwoWayOperators() {
+    let date1 = NSDate(timeIntervalSince1970: 1)
+    let date2 = NSDate(timeIntervalSince1970: 2)
+    let date3 = NSDate(timeIntervalSince1970: 3)
+    let date4 = NSDate(timeIntervalSince1970: 4)
+    
+    let dynamicDriver1 = Dynamic<NSDate>(date1)
+    let dynamicDriver2 = Dynamic<NSDate>(date2)
+    let datePicker1 = UIDatePicker()
+    let datePicker2 = UIDatePicker()
+    
+    XCTAssertEqual(dynamicDriver1.value, date1, "Intial value")
+    XCTAssertEqual(dynamicDriver2.value, date2, "Intial value")
+    
+    dynamicDriver1 <->> datePicker1
+    datePicker1 <->> datePicker2
+    datePicker2 <->> dynamicDriver2
+    
+    XCTAssertEqual(dynamicDriver1.value, date1, "Value after binding")
+    XCTAssertEqual(dynamicDriver2.value, date1, "Value after binding")
+    
+    dynamicDriver1.value = date3
+    
+    XCTAssertEqual(dynamicDriver1.value, date3, "Value after dynamic update")
+    XCTAssertEqual(dynamicDriver2.value, date3, "Value after dynamic update")
+    
+    dynamicDriver2.value = date4
+    
+    XCTAssertEqual(dynamicDriver1.value, date4, "Value after dynamic update")
+    XCTAssertEqual(dynamicDriver2.value, date4, "Value after dynamic update")
+
+  }
 }

--- a/BondTests/UIDatePickerTests.swift
+++ b/BondTests/UIDatePickerTests.swift
@@ -1,0 +1,35 @@
+//
+//  UIDatePickerTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIDatePickerTests: XCTestCase {
+
+  func testUIDatePickerDynamic() {
+    let date1 = NSDate(timeIntervalSince1970: 10)
+    let date2 = NSDate(timeIntervalSince1970: 10000)
+    let date3 = NSDate(timeIntervalSince1970: 20000)
+    
+    var dynamicDriver = Dynamic<NSDate>(date1)
+    let datePicker = UIDatePicker()
+    
+        datePicker.date = date2
+        XCTAssert(datePicker.date == date2, "Initial value")
+    
+        dynamicDriver <->> datePicker.dynDate
+        XCTAssert(datePicker.date == date1, "DatePicker value after binding")
+    
+        dynamicDriver.value = date3
+        XCTAssert(datePicker.date == date3, "DatePicker value reflects dynamic value change")
+    
+        datePicker.dynDate.value = date2 // ideally we should simulate user input
+        XCTAssert(dynamicDriver.value == date2, "Dynamic value reflects DatePicker value change")
+  }
+}

--- a/BondTests/UIImageViewTests.swift
+++ b/BondTests/UIImageViewTests.swift
@@ -1,0 +1,29 @@
+//
+//  UIImageViewTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIImageViewTests: XCTestCase {
+
+  func testUIImageViewBond() {
+    let image = UIImage()
+    var dynamicDriver = Dynamic<UIImage?>(nil)
+    let imageView = UIImageView()
+    
+    imageView.image = image
+    XCTAssert(imageView.image == image, "Initial value")
+    
+    dynamicDriver ->> imageView.designatedBond
+    XCTAssert(imageView.image == nil, "Value after binding")
+    
+    imageView.image = image
+    XCTAssert(imageView.image == image, "Value after dynamic change")
+  }
+}

--- a/BondTests/UILabelTests.swift
+++ b/BondTests/UILabelTests.swift
@@ -1,0 +1,42 @@
+//
+//  UILabelTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UILabelTests: XCTestCase {
+
+  func testUILabelBond() {
+    var dynamicDriver = Dynamic<String>("b")
+    let label = UILabel()
+    
+    label.text = "a"
+    XCTAssert(label.text == "a", "Initial value")
+    
+    dynamicDriver ->> label.designatedBond
+    XCTAssert(label.text == "b", "Value after binding")
+    
+    dynamicDriver.value = "c"
+    XCTAssert(label.text == "c", "Value after dynamic change")
+  }
+  
+  func testUILabelAttributedTextBond() {
+    var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
+    let label = UILabel()
+    
+    label.text = "a"
+    XCTAssert(label.text == "a", "Initial value")
+    
+    dynamicDriver ->> label.dynAttributedText
+    XCTAssert(label.attributedText.string == "b", "Value after binding")
+    
+    dynamicDriver.value = NSAttributedString(string: "c")
+    XCTAssert(label.attributedText.string == "c", "Value after dynamic change")
+  }
+}

--- a/BondTests/UIProgressViewTests.swift
+++ b/BondTests/UIProgressViewTests.swift
@@ -1,0 +1,28 @@
+//
+//  UIProgressViewTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIProgressViewTests: XCTestCase {
+
+  func testUIProgressViewBond() {
+    var dynamicDriver = Dynamic<Float>(0)
+    let progressView = UIProgressView()
+    
+    progressView.progress = 0.1
+    XCTAssert(progressView.progress == 0.1, "Initial value")
+    
+    dynamicDriver ->> progressView.designatedBond
+    XCTAssert(progressView.progress == 0.0, "Value after binding")
+    
+    dynamicDriver.value = 0.5
+    XCTAssert(progressView.progress == 0.5, "Value after dynamic change")
+  }
+}

--- a/BondTests/UISliderTests.swift
+++ b/BondTests/UISliderTests.swift
@@ -29,4 +29,51 @@ class UISliderTests: XCTestCase {
     slider.sendActionsForControlEvents(.ValueChanged) // simulate user input
     XCTAssert(dynamicDriver.value == 0.8, "Dynamic value reflects slider value change")
   }
+  
+  func testOneWayOperators() {
+    var bondedValue: Float = 0
+    let bond = Bond { bondedValue = $0 }
+    let dynamicDriver = Dynamic<Float>(0.1)
+    let slider1 = UISlider()
+    let slider2 = UISlider()
+    
+    XCTAssertEqual(bondedValue, Float(0), "Initial value")
+    
+    dynamicDriver ->> slider1
+    slider1 ->> slider2
+    slider2 ->> bond
+    
+    XCTAssertEqual(bondedValue, Float(0.1), "Value after binding")
+    
+    dynamicDriver.value = 0.7
+    
+    XCTAssertEqual(bondedValue, Float(0.7), "Value after change")
+  }
+
+  func testTwoWayOperators() {
+    let dynamicDriver1 = Dynamic<Float>(0.1)
+    let dynamicDriver2 = Dynamic<Float>(0.2)
+    let slider1 = UISlider()
+    let slider2 = UISlider()
+    
+    XCTAssertEqual(dynamicDriver1.value, Float(0.1), "Initial value")
+    XCTAssertEqual(dynamicDriver2.value, Float(0.2), "Initial value")
+    
+    dynamicDriver1 <->> slider1
+    slider1 <->> slider2
+    slider2 <->> dynamicDriver2
+    
+    XCTAssertEqual(dynamicDriver1.value, Float(0.1), "Value after binding")
+    XCTAssertEqual(dynamicDriver2.value, Float(0.1), "Value after binding")
+    
+    dynamicDriver1.value = 0.3
+    
+    XCTAssertEqual(dynamicDriver1.value, Float(0.3), "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, Float(0.3), "Value after change")
+
+    dynamicDriver2.value = 0.4
+    
+    XCTAssertEqual(dynamicDriver1.value, Float(0.4), "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, Float(0.4), "Value after change")
+  }
 }

--- a/BondTests/UISliderTests.swift
+++ b/BondTests/UISliderTests.swift
@@ -1,0 +1,31 @@
+//
+//  UISliderTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UISliderTests: XCTestCase {
+
+  func testUISliderDynamic() {
+    var dynamicDriver = Dynamic<Float>(0)
+    let slider = UISlider()
+    
+    slider.value = 0.1
+    XCTAssert(slider.value == 0.1, "Initial value")
+    
+    dynamicDriver <->> slider.dynValue
+    XCTAssert(slider.value == 0.0, "Slider value after binding")
+    
+    dynamicDriver.value = 0.5
+    XCTAssert(slider.value == 0.5, "Slider value reflects dynamic value change")
+    
+    slider.dynValue.value = 0.8 // ideally we should simulate user input
+    XCTAssert(dynamicDriver.value == 0.8, "Dynamic value reflects slider value change")
+  }
+}

--- a/BondTests/UISliderTests.swift
+++ b/BondTests/UISliderTests.swift
@@ -25,7 +25,8 @@ class UISliderTests: XCTestCase {
     dynamicDriver.value = 0.5
     XCTAssert(slider.value == 0.5, "Slider value reflects dynamic value change")
     
-    slider.dynValue.value = 0.8 // ideally we should simulate user input
+    slider.value = 0.8
+    slider.sendActionsForControlEvents(.ValueChanged) // simulate user input
     XCTAssert(dynamicDriver.value == 0.8, "Dynamic value reflects slider value change")
   }
 }

--- a/BondTests/UISwitchTests.swift
+++ b/BondTests/UISwitchTests.swift
@@ -29,4 +29,51 @@ class UISwitchTests: XCTestCase {
     uiSwitch.sendActionsForControlEvents(.ValueChanged) //simulate user input
     XCTAssert(dynamicDriver.value == false, "Dynamic value reflects switch value change")
   }
+  
+  func testOneWayOperators() {
+    var bondedValue = true
+    let bond = Bond { bondedValue = $0 }
+    let dynamicDriver = Dynamic<Bool>(false)
+    let switch1 = UISwitch()
+    let switch2 = UISwitch()
+    
+    XCTAssertEqual(bondedValue, true, "Initial value")
+    
+    dynamicDriver ->> switch1
+    switch1 ->> switch2
+    switch2 ->> bond
+    
+    XCTAssertEqual(bondedValue, false, "Value after binding")
+    
+    dynamicDriver.value = true
+    
+    XCTAssertEqual(bondedValue, true, "Value after change")
+  }
+  
+  func testTwoWayOperators() {
+    let dynamicDriver1 = Dynamic<Bool>(true)
+    let dynamicDriver2 = Dynamic<Bool>(false)
+    let switch1 = UISwitch()
+    let switch2 = UISwitch()
+    
+    XCTAssertEqual(dynamicDriver1.value, true, "Initial value")
+    XCTAssertEqual(dynamicDriver2.value, false, "Initial value")
+    
+    dynamicDriver1 <->> switch1
+    switch1 <->> switch2
+    switch2 <->> dynamicDriver2
+    
+    XCTAssertEqual(dynamicDriver1.value, true, "Value after binding")
+    XCTAssertEqual(dynamicDriver2.value, true, "Value after binding")
+    
+    dynamicDriver1.value = false
+    
+    XCTAssertEqual(dynamicDriver1.value, false, "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, false, "Value after change")
+
+    dynamicDriver2.value = true
+    
+    XCTAssertEqual(dynamicDriver1.value, true, "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, true, "Value after change")
+  }
 }

--- a/BondTests/UISwitchTests.swift
+++ b/BondTests/UISwitchTests.swift
@@ -25,7 +25,8 @@ class UISwitchTests: XCTestCase {
     dynamicDriver.value = true
     XCTAssert(uiSwitch.on == true, "Switch value reflects dynamic value change")
     
-    uiSwitch.dynOn.value = false // ideally we should simulate user input
+    uiSwitch.on = false
+    uiSwitch.sendActionsForControlEvents(.ValueChanged) //simulate user input
     XCTAssert(dynamicDriver.value == false, "Dynamic value reflects switch value change")
   }
 }

--- a/BondTests/UISwitchTests.swift
+++ b/BondTests/UISwitchTests.swift
@@ -1,0 +1,31 @@
+//
+//  UISwitchTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UISwitchTests: XCTestCase {
+
+  func testUISwitchDynamic() {
+    var dynamicDriver = Dynamic<Bool>(false)
+    let uiSwitch = UISwitch()
+    
+    uiSwitch.on = true
+    XCTAssert(uiSwitch.on == true, "Initial value")
+    
+    dynamicDriver <->> uiSwitch.dynOn
+    XCTAssert(uiSwitch.on == false, "Switch value after binding")
+    
+    dynamicDriver.value = true
+    XCTAssert(uiSwitch.on == true, "Switch value reflects dynamic value change")
+    
+    uiSwitch.dynOn.value = false // ideally we should simulate user input
+    XCTAssert(dynamicDriver.value == false, "Dynamic value reflects switch value change")
+  }
+}

--- a/BondTests/UITextFieldTests.swift
+++ b/BondTests/UITextFieldTests.swift
@@ -25,8 +25,9 @@ class UITextFieldTests: XCTestCase {
     dynamicDriver.value = "c"
     XCTAssert(textField.text == "c", "Text field value reflects dynamic value change")
     
-    textField.dynText.value = "d" // ideally we should simulate user input
-    XCTAssert(textField.dynText.value == "d", "Dynamic value reflects text field value change")
-    XCTAssert(dynamicDriver.value == "d", "Dynamic value reflects text view field change")
+    textField.text = "d"
+    textField.sendActionsForControlEvents(.EditingChanged) //simulate user input
+    XCTAssertEqual(textField.dynText.value, "d", "Dynamic value reflects text field value change")
+    XCTAssertEqual(dynamicDriver.value, "d", "Dynamic value reflects text view field change")
   }
 }

--- a/BondTests/UITextFieldTests.swift
+++ b/BondTests/UITextFieldTests.swift
@@ -30,4 +30,63 @@ class UITextFieldTests: XCTestCase {
     XCTAssertEqual(textField.dynText.value, "d", "Dynamic value reflects text field value change")
     XCTAssertEqual(dynamicDriver.value, "d", "Dynamic value reflects text view field change")
   }
+  
+  func testOneWayOperators() {
+    var bondedValue = ""
+    let bond = Bond { bondedValue = $0 }
+    let dynamicDriver = Dynamic<String>("a")
+    let textField1 = UITextField()
+    let textField2 = UITextField()
+    let textView = UITextView()
+    let label = UILabel()
+    
+    XCTAssertEqual(bondedValue, "", "Initial value")
+    XCTAssertEqual(textView.text, "", "Initial value")
+    XCTAssertEqual(label.text, nil, "Initial value")
+    
+    dynamicDriver ->> textField1
+    textField1 ->> textField2
+    textField2 ->> bond
+    textField2 ->> textView
+    textField2 ->> label
+    
+    XCTAssertEqual(bondedValue, "a", "Value after binding")
+    XCTAssertEqual(textView.text, "a", "Value after binding")
+    XCTAssertEqual(label.text, "a", "Value after binding")
+    
+    dynamicDriver.value = "b"
+    
+    XCTAssertEqual(bondedValue, "b", "Value after change")
+    XCTAssertEqual(textView.text, "b", "Value after change")
+    XCTAssertEqual(label.text, "b", "Value after change")
+  }
+  
+  func testTwoWayOperators() {
+    let dynamicDriver1 = Dynamic<String>("a")
+    let dynamicDriver2 = Dynamic<String>("z")
+    let textField1 = UITextField()
+    let textField2 = UITextField()
+    let textView = UITextView()
+
+    XCTAssertEqual(dynamicDriver1.value, "a", "Initial value")
+    XCTAssertEqual(dynamicDriver2.value, "z", "Initial value")
+
+    dynamicDriver1 <->> textField1
+    textField1 <->> textView
+    textView <->> textField2
+    textField2 <->> dynamicDriver2
+    
+    XCTAssertEqual(dynamicDriver1.value, "a", "After binding")
+    XCTAssertEqual(dynamicDriver2.value, "a", "After binding")
+    
+    dynamicDriver1.value = "c"
+
+    XCTAssertEqual(dynamicDriver1.value, "c", "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, "c", "Value after change")
+    
+    dynamicDriver2.value = "y"
+    
+    XCTAssertEqual(dynamicDriver1.value, "y", "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, "y", "Value after change")
+  }
 }

--- a/BondTests/UITextFieldTests.swift
+++ b/BondTests/UITextFieldTests.swift
@@ -1,0 +1,32 @@
+//
+//  UITextFieldTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UITextFieldTests: XCTestCase {
+
+  func testUITextFieldDynamic() {
+    var dynamicDriver = Dynamic<String>("b")
+    let textField = UITextField()
+    
+    textField.text = "a"
+    XCTAssert(textField.text == "a", "Initial value")
+    
+    dynamicDriver <->> textField.dynText
+    XCTAssert(textField.text == "b", "Text field value after binding")
+    
+    dynamicDriver.value = "c"
+    XCTAssert(textField.text == "c", "Text field value reflects dynamic value change")
+    
+    textField.dynText.value = "d" // ideally we should simulate user input
+    XCTAssert(textField.dynText.value == "d", "Dynamic value reflects text field value change")
+    XCTAssert(dynamicDriver.value == "d", "Dynamic value reflects text view field change")
+  }
+}

--- a/BondTests/UITextViewTests.swift
+++ b/BondTests/UITextViewTests.swift
@@ -50,5 +50,74 @@ class UITextViewTests: XCTestCase {
     XCTAssert(dynamicDriver.value.string == "d", "Dynamic value reflects text view value change")
   }
   
+  func testOneWayOperators() {
+    var bondedValue: String = ""
+    let bond = Bond { bondedValue = $0 }
+    let dynamicDriver = Dynamic<String>("a")
+    let textView1 = UITextView()
+    let textView2 = UITextView()
+    let textField = UITextField()
+    let label = UILabel()
+    
+    XCTAssertEqual(bondedValue, "", "Initial value")
+    XCTAssertEqual(textField.text, "", "Initial value")
+    XCTAssertEqual(label.text, nil, "Initial value")
+    
+    dynamicDriver ->> textView1
+    textView1 ->> textView2
+    textView2 ->> bond
+    textView2 ->> textField
+    textView2 ->> label
+    
+    XCTAssertEqual(bondedValue, "a", "Value after binding")
+    XCTAssertEqual(textField.text, "a", "Value after binding")
+    XCTAssertEqual(label.text, "a", "Value after binding")
+    
+    dynamicDriver.value = "b"
+    
+    XCTAssertEqual(bondedValue, "b", "Value after change")
+    XCTAssertEqual(textField.text, "b", "Value after change")
+    XCTAssertEqual(label.text, "b", "Value after change")
+  }
+  
+  func testTwoWayOperators() {
+    let dynamicDriver1 = Dynamic<String>("a")
+    let dynamicDriver2 = Dynamic<String>("z")
+    let textView1 = UITextView()
+    let textView2 = UITextView()
+    let textField = UITextField()
+    textField.text = "1"
+    
+    XCTAssertEqual(dynamicDriver1.value, "a", "Initial value")
+    XCTAssertEqual(dynamicDriver2.value, "z", "Initial value")
+    XCTAssertEqual(textField.text, "1", "Initial value")
+    
+    dynamicDriver1 <->> textView1
+    textView1 <->> textView2
+    textView2 <->> dynamicDriver2
+    textView2 <->> textField
+    
+    XCTAssertEqual(dynamicDriver1.value, "a", "Value after binding")
+    XCTAssertEqual(dynamicDriver2.value, "a", "Value after binding")
+    XCTAssertEqual(textField.text, "a", "Value after binding")
+    
+    dynamicDriver1.value = "b"
+    
+    XCTAssertEqual(dynamicDriver1.value, "b", "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, "b", "Value after change")
+    XCTAssertEqual(textField.text, "b", "Value after change")
 
+    dynamicDriver2.value = "y"
+    
+    XCTAssertEqual(dynamicDriver1.value, "y", "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, "y", "Value after change")
+    XCTAssertEqual(textField.text, "y", "Value after change")
+    
+    textField.text = "2"
+    textField.sendActionsForControlEvents(.EditingChanged)
+    
+    XCTAssertEqual(dynamicDriver1.value, "2", "Value after change")
+    XCTAssertEqual(dynamicDriver2.value, "2", "Value after change")
+    XCTAssertEqual(textField.text, "2", "Value after change")
+  }
 }

--- a/BondTests/UITextViewTests.swift
+++ b/BondTests/UITextViewTests.swift
@@ -1,0 +1,54 @@
+//
+//  UITextViewTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UITextViewTests: XCTestCase {
+
+  func testUITextViewDynamic() {
+    var dynamicDriver = Dynamic<String>("b")
+    let textView = UITextView()
+    
+    textView.text = "a"
+    XCTAssert(textView.text == "a", "Initial value")
+    
+    dynamicDriver <->> textView.dynText
+    XCTAssert(textView.text == "b", "Text view value after binding")
+    
+    dynamicDriver.value = "c"
+    XCTAssert(textView.text == "c", "Text view value reflects dynamic value change")
+    
+    textView.text = "d"
+    NSNotificationCenter.defaultCenter().postNotificationName(UITextViewTextDidChangeNotification, object: textView)
+    XCTAssert(textView.dynText.value == "d", "Dynamic value reflects text view value change")
+    XCTAssert(dynamicDriver.value == "d", "Dynamic value reflects text view value change")
+  }
+  
+  func testUITextViewAttributedDynamic() {
+    var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
+    let textView = UITextView()
+    
+    textView.attributedText = NSAttributedString(string: "a")
+    XCTAssert(textView.attributedText.string == "a", "Initial value")
+    
+    dynamicDriver <->> textView.dynAttributedText
+    XCTAssert(textView.attributedText.string == "b", "Text view value after binding")
+    
+    dynamicDriver.value = NSAttributedString(string: "c")
+    XCTAssert(textView.attributedText.string == "c", "Text view value reflects dynamic value change")
+    
+    textView.attributedText = NSAttributedString(string: "d")
+    NSNotificationCenter.defaultCenter().postNotificationName(UITextViewTextDidChangeNotification, object: textView)
+    XCTAssert(textView.dynAttributedText.value.string == "d", "Dynamic value reflects text view value change")
+    XCTAssert(dynamicDriver.value.string == "d", "Dynamic value reflects text view value change")
+  }
+  
+
+}

--- a/BondTests/UIViewTests.swift
+++ b/BondTests/UIViewTests.swift
@@ -1,0 +1,56 @@
+//
+//  UIViewTests.swift
+//  Bond
+//
+//  Created by Anthony Egerton on 11/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+import Bond
+
+class UIViewTests: XCTestCase {
+
+  func testUIViewHiddenBond() {
+    var dynamicDriver = Dynamic<Bool>(false)
+    let view = UIView()
+    
+    view.hidden = true
+    XCTAssert(view.hidden == true, "Initial value")
+    
+    dynamicDriver ->> view.dynHidden
+    XCTAssert(view.hidden == false, "Value after binding")
+    
+    dynamicDriver.value = true
+    XCTAssert(view.hidden == true, "Value after dynamic change")
+  }
+  
+  func testUIViewAlphaBond() {
+    var dynamicDriver = Dynamic<CGFloat>(0.1)
+    let view = UIView()
+    
+    view.alpha = 0.0
+    XCTAssert(abs(view.alpha - 0.0) < 0.0001, "Initial value")
+    
+    dynamicDriver ->> view.dynAlpha
+    XCTAssert(abs(view.alpha - 0.1) < 0.0001, "Value after binding")
+    
+    dynamicDriver.value = 0.5
+    XCTAssert(abs(view.alpha - 0.5) < 0.0001, "Value after dynamic change")
+  }
+  
+  func testUIViewBackgroundColorBond() {
+    var dynamicDriver = Dynamic<UIColor>(UIColor.blackColor())
+    let view = UIView()
+    
+    view.backgroundColor = UIColor.redColor()
+    XCTAssert(view.backgroundColor == UIColor.redColor(), "Initial value")
+    
+    dynamicDriver ->> view.dynBackgroundColor
+    XCTAssert(view.backgroundColor == UIColor.blackColor(), "Value after binding")
+    
+    dynamicDriver.value = UIColor.blueColor()
+    XCTAssert(view.backgroundColor == UIColor.blueColor(), "Value after dynamic change")
+  }
+}

--- a/iOSAppForTesting/AppDelegate.swift
+++ b/iOSAppForTesting/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  iOSAppForTesting
+//
+//  Created by Anthony Egerton on 15/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+  var window: UIWindow?
+
+
+  func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    // Override point for customization after application launch.
+    return true
+  }
+
+  func applicationWillResignActive(application: UIApplication) {
+    // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+    // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+  }
+
+  func applicationDidEnterBackground(application: UIApplication) {
+    // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+    // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+  }
+
+  func applicationWillEnterForeground(application: UIApplication) {
+    // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+  }
+
+  func applicationDidBecomeActive(application: UIApplication) {
+    // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+  }
+
+  func applicationWillTerminate(application: UIApplication) {
+    // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+  }
+
+
+}
+

--- a/iOSAppForTesting/Base.lproj/LaunchScreen.xib
+++ b/iOSAppForTesting/Base.lproj/LaunchScreen.xib
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.XIB" version="3.0" toolsVersion="6214" systemVersion="14A314h" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6207"/>
+        <capability name="Constraints with non-1.0 multipliers" minToolsVersion="5.1"/>
+    </dependencies>
+    <objects>
+        <placeholder placeholderIdentifier="IBFilesOwner" id="-1" userLabel="File's Owner"/>
+        <placeholder placeholderIdentifier="IBFirstResponder" id="-2" customClass="UIResponder"/>
+        <view contentMode="scaleToFill" id="iN0-l3-epB">
+            <rect key="frame" x="0.0" y="0.0" width="480" height="480"/>
+            <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+            <subviews>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="  Copyright (c) 2015 Bond. All rights reserved." textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" minimumFontSize="9" translatesAutoresizingMaskIntoConstraints="NO" id="8ie-xW-0ye">
+                    <rect key="frame" x="20" y="439" width="441" height="21"/>
+                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+                <label opaque="NO" clipsSubviews="YES" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="iOSAppForTesting" textAlignment="center" lineBreakMode="middleTruncation" baselineAdjustment="alignBaselines" minimumFontSize="18" translatesAutoresizingMaskIntoConstraints="NO" id="kId-c2-rCX">
+                    <rect key="frame" x="20" y="140" width="441" height="43"/>
+                    <fontDescription key="fontDescription" type="boldSystem" pointSize="36"/>
+                    <color key="textColor" cocoaTouchSystemColor="darkTextColor"/>
+                    <nil key="highlightedColor"/>
+                </label>
+            </subviews>
+            <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+            <constraints>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="centerY" secondItem="iN0-l3-epB" secondAttribute="bottom" multiplier="1/3" constant="1" id="5cJ-9S-tgC"/>
+                <constraint firstAttribute="centerX" secondItem="kId-c2-rCX" secondAttribute="centerX" id="Koa-jz-hwk"/>
+                <constraint firstAttribute="bottom" secondItem="8ie-xW-0ye" secondAttribute="bottom" constant="20" id="Kzo-t9-V3l"/>
+                <constraint firstItem="8ie-xW-0ye" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="MfP-vx-nX0"/>
+                <constraint firstAttribute="centerX" secondItem="8ie-xW-0ye" secondAttribute="centerX" id="ZEH-qu-HZ9"/>
+                <constraint firstItem="kId-c2-rCX" firstAttribute="leading" secondItem="iN0-l3-epB" secondAttribute="leading" constant="20" symbolic="YES" id="fvb-Df-36g"/>
+            </constraints>
+            <nil key="simulatedStatusBarMetrics"/>
+            <freeformSimulatedSizeMetrics key="simulatedDestinationMetrics"/>
+            <point key="canvasLocation" x="548" y="455"/>
+        </view>
+    </objects>
+</document>

--- a/iOSAppForTesting/Base.lproj/Main.storyboard
+++ b/iOSAppForTesting/Base.lproj/Main.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="600" height="600"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/iOSAppForTesting/Images.xcassets/AppIcon.appiconset/Contents.json
+++ b/iOSAppForTesting/Images.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,68 @@
+{
+  "images" : [
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "29x29",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "40x40",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "60x60",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "29x29",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "40x40",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "76x76",
+      "scale" : "2x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/iOSAppForTesting/Info.plist
+++ b/iOSAppForTesting/Info.plist
@@ -1,0 +1,47 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>swift.bond.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UILaunchStoryboardName</key>
+	<string>LaunchScreen</string>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>armv7</string>
+	</array>
+	<key>UISupportedInterfaceOrientations</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationPortraitUpsideDown</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+</dict>
+</plist>

--- a/iOSAppForTesting/ViewController.swift
+++ b/iOSAppForTesting/ViewController.swift
@@ -1,0 +1,25 @@
+//
+//  ViewController.swift
+//  iOSAppForTesting
+//
+//  Created by Anthony Egerton on 15/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+
+class ViewController: UIViewController {
+
+  override func viewDidLoad() {
+    super.viewDidLoad()
+    // Do any additional setup after loading the view, typically from a nib.
+  }
+
+  override func didReceiveMemoryWarning() {
+    super.didReceiveMemoryWarning()
+    // Dispose of any resources that can be recreated.
+  }
+
+
+}
+

--- a/iOSAppForTestingTests/Info.plist
+++ b/iOSAppForTestingTests/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>swift.bond.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>BNDL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+</dict>
+</plist>

--- a/iOSAppForTestingTests/iOSAppForTestingTests.swift
+++ b/iOSAppForTestingTests/iOSAppForTestingTests.swift
@@ -1,0 +1,36 @@
+//
+//  iOSAppForTestingTests.swift
+//  iOSAppForTestingTests
+//
+//  Created by Anthony Egerton on 15/03/2015.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import XCTest
+
+class iOSAppForTestingTests: XCTestCase {
+    
+    override func setUp() {
+        super.setUp()
+        // Put setup code here. This method is called before the invocation of each test method in the class.
+    }
+    
+    override func tearDown() {
+        // Put teardown code here. This method is called after the invocation of each test method in the class.
+        super.tearDown()
+    }
+    
+    func testExample() {
+        // This is an example of a functional test case.
+        XCTAssert(true, "Pass")
+    }
+    
+    func testPerformanceExample() {
+        // This is an example of a performance test case.
+        self.measureBlock() {
+            // Put the code you want to measure the time of here.
+        }
+    }
+    
+}


### PR DESCRIPTION
Bond looks very useful.
I was looking at the UIKit tests and thought I could add some to cover the operators.
I split the tests to match the split up of the UIKit extensions code.
Also I added an iOS app as a test host so you can send control events in the tests.

Hope you find them useful.