### PR TITLE
Rearrange support in Table Views

### DIFF
--- a/Bond/Bond+Arrays.swift
+++ b/Bond/Bond+Arrays.swift
@@ -41,6 +41,8 @@ public class ArrayBond<T>: Bond<Array<T>> {
   public var willUpdateListener: ((DynamicArray<T>, [Int]) -> Void)?
   public var didUpdateListener: ((DynamicArray<T>, [Int]) -> Void)?
 
+  public var willMoveListener: ((DynamicArray<T>, [Int]) -> Void)?
+  public var didMoveListener: ((DynamicArray<T>, [Int]) -> Void)?
   
   override public init() {
     super.init()
@@ -155,6 +157,13 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
     value.removeAll(keepCapacity: keepCapacity)
     dispatchDidRemove(Array<Int>(0..<count))
   }
+    
+  public func move(from: Int, to:Int) {
+    dispatchWillMove([from, to])
+    let elem = value.removeAtIndex(from)
+    value.insert(elem, atIndex: to)
+    dispatchDidMove([from, to])
+  }
   
   public subscript(index: Int) -> T {
     get {
@@ -224,6 +233,22 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
       }
     }
   }
+    
+    private func dispatchWillMove(indices: [Int]) {
+        for bondBox in bonds {
+            if let arrayBond = bondBox.bond as? ArrayBond {
+                arrayBond.willMoveListener?(self, indices)
+            }
+        }
+    }
+    
+    private func dispatchDidMove(indices: [Int]) {
+        for bondBox in bonds {
+            if let arrayBond = bondBox.bond as? ArrayBond {
+                arrayBond.didMoveListener?(self, indices)
+            }
+        }
+    }
 }
 
 public struct DynamicArrayGenerator<T>: GeneratorType {

--- a/Bond/Bond+UITableView.swift
+++ b/Bond/Bond+UITableView.swift
@@ -153,6 +153,13 @@ private class UITableViewDataSourceSectionBond<T>: ArrayBond<UITableViewCell> {
         tableView.endUpdates()
       }
     }
+    self.didMoveListener = { [unowned self] a, i in
+      if let tableView = self.tableView {
+        tableView.beginUpdates()
+        tableView.moveRowAtIndexPath(NSIndexPath(forRow: i[0], inSection: self.section), toIndexPath: NSIndexPath(forRow: i[1], inSection: self.section))
+        tableView.endUpdates()
+      }
+    }
   }
   
   deinit {

--- a/BondTests/FoundationTests.swift
+++ b/BondTests/FoundationTests.swift
@@ -68,7 +68,7 @@ class FoundationTests: XCTestCase {
   
   func testKVO4() {
     let user = User(name: nil)
-    let height: Dynamic<Float> = dynamicObservableFor(user, keyPath: "height", from: { ($0 as NSNumber).floatValue }, to: { NSNumber(float: $0) })
+    let height: Dynamic<Float> = dynamicObservableFor(user, keyPath: "height", from: { ($0 as! NSNumber).floatValue }, to: { NSNumber(float: $0) })
     
     XCTAssert(abs(height.value - 0) < 0.0001, "Value after initialization.")
     


### PR DESCRIPTION
Added a listener and handler for moving elements within a section. Maybe we want to be able to move rows between sections as well? What do you think of the implementation?

Note the change in FoundationTests.swift is for Swift 1.2.