### PR TITLE
Add a `setArray:` operation, reset event, tests, table view reload support

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -51,6 +51,7 @@
 		907391C01ADF2C99008CE36A /* Bond+NSStatusBarButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907391B81ADF2C99008CE36A /* Bond+NSStatusBarButton.swift */; };
 		907391C11ADF2C99008CE36A /* Bond+NSTextField.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907391B91ADF2C99008CE36A /* Bond+NSTextField.swift */; };
 		907391C21ADF2C99008CE36A /* Bond+NSTextView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 907391BA1ADF2C99008CE36A /* Bond+NSTextView.swift */; };
+		CC581F761AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CC581F751AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift */; };
 		DCA979741A83C3A200DD4A30 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA979691A83C3A100DD4A30 /* Bond.framework */; };
 		DCA979821A83C4F500DD4A30 /* DynamicTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BD21A7C242900A13B6B /* DynamicTests.swift */; };
 		DCA979831A83C4F800DD4A30 /* BondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BC01A7C217100A13B6B /* BondTests.swift */; };
@@ -157,6 +158,7 @@
 		907391B81ADF2C99008CE36A /* Bond+NSStatusBarButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+NSStatusBarButton.swift"; sourceTree = "<group>"; };
 		907391B91ADF2C99008CE36A /* Bond+NSTextField.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+NSTextField.swift"; sourceTree = "<group>"; };
 		907391BA1ADF2C99008CE36A /* Bond+NSTextView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+NSTextView.swift"; sourceTree = "<group>"; };
+		CC581F751AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewDataSourceTests.swift; sourceTree = "<group>"; };
 		DCA979691A83C3A100DD4A30 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EC0301741AAA23C9004B3071 /* Bond+UICollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+UICollectionView.swift"; sourceTree = "<group>"; };
@@ -226,6 +228,7 @@
 		03A5DC961AAF9612007616B4 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
+				CC581F751AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift */,
 				03A5DC991AAF971F007616B4 /* UIViewTests.swift */,
 				03A5DC9F1AAF982D007616B4 /* UIImageViewTests.swift */,
 				03A5DC9D1AAF97E9007616B4 /* UIProgressViewTests.swift */,
@@ -676,6 +679,7 @@
 				03A5DC951AAF95EB007616B4 /* UIButtonTests.swift in Sources */,
 				EC847EB11AA796F5002971B8 /* FoundationTests.swift in Sources */,
 				03A5DCAE1AAF9C3F007616B4 /* UIDatePickerTests.swift in Sources */,
+				CC581F761AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift in Sources */,
 				03A5DC9C1AAF977F007616B4 /* UILabelTests.swift in Sources */,
 				03A5DCAA1AAF99C2007616B4 /* UITextViewTests.swift in Sources */,
 				03A5DCA81AAF995F007616B4 /* UITextFieldTests.swift in Sources */,

--- a/Bond/Bond+UITableView.swift
+++ b/Bond/Bond+UITableView.swift
@@ -245,6 +245,12 @@ public class UITableViewDataSourceBond<T>: ArrayBond<DynamicArray<UITableViewCel
         }
       }
     }
+    
+    self.didResetListener = { [weak self] array in
+      if let tableView = self?.tableView {
+        tableView.reloadData()
+      }
+    }
   }
   
   public func bind(dynamic: DynamicArray<UITableViewCell>) {

--- a/BondTests/UITableViewDataSourceTests.swift
+++ b/BondTests/UITableViewDataSourceTests.swift
@@ -1,0 +1,122 @@
+
+import UIKit
+import Bond
+import XCTest
+
+enum TableOperation {
+  case InsertRows([NSIndexPath])
+  case DeleteRows([NSIndexPath])
+  case ReloadRows([NSIndexPath])
+  case InsertSections(NSIndexSet)
+  case DeleteSections(NSIndexSet)
+  case ReloadSections(NSIndexSet)
+  case ReloadData
+}
+
+func ==(op0: TableOperation, op1: TableOperation) -> Bool {
+  switch (op0, op1) {
+  case let (.InsertRows(paths0), .InsertRows(paths1)):
+    return paths0 == paths1
+  case let (.DeleteRows(paths0), .DeleteRows(paths1)):
+    return paths0 == paths1
+  case let (.ReloadRows(paths0), .ReloadRows(paths1)):
+    return paths0 == paths1
+  case let (.InsertSections(i0), .InsertSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case let (.DeleteSections(i0), .DeleteSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case let (.ReloadSections(i0), .ReloadSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case (.ReloadData, .ReloadData):
+    return true
+  default:
+    return false
+  }
+}
+
+extension TableOperation: Equatable, Printable {
+  var description: String {
+    switch self {
+    case let .InsertRows(indexPaths):
+      return "InsertRows(\(indexPaths)"
+    case let .DeleteRows(indexPaths):
+      return "DeleteRows(\(indexPaths)"
+    case let .ReloadRows(indexPaths):
+      return "ReloadRows(\(indexPaths)"
+    case let .InsertSections(indices):
+      return "InsertSections(\(indices)"
+    case let .DeleteSections(indices):
+      return "DeleteSections(\(indices)"
+    case let .ReloadSections(indices):
+      return "ReloadSections(\(indices)"
+    case .ReloadData:
+      return "ReloadData"
+    }
+  }
+}
+
+class TestTableView: UITableView {
+  var operations = [TableOperation]()
+  override func insertRowsAtIndexPaths(indexPaths: [AnyObject], withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.InsertRows(indexPaths as! [NSIndexPath]))
+    super.insertRowsAtIndexPaths(indexPaths, withRowAnimation: animation)
+  }
+  
+  override func deleteRowsAtIndexPaths(indexPaths: [AnyObject], withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.DeleteRows(indexPaths as! [NSIndexPath]))
+    super.deleteRowsAtIndexPaths(indexPaths, withRowAnimation: animation)
+  }
+  
+  override func reloadRowsAtIndexPaths(indexPaths: [AnyObject], withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.ReloadRows(indexPaths as! [NSIndexPath]))
+    super.reloadRowsAtIndexPaths(indexPaths, withRowAnimation: animation)
+  }
+  
+  override func insertSections(sections: NSIndexSet, withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.InsertSections(sections))
+    super.insertSections(sections, withRowAnimation: animation)
+  }
+  
+  override func deleteSections(sections: NSIndexSet, withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.DeleteSections(sections))
+    super.deleteSections(sections, withRowAnimation: animation)
+  }
+  
+  override func reloadSections(sections: NSIndexSet, withRowAnimation animation: UITableViewRowAnimation) {
+    operations.append(.ReloadSections(sections))
+    super.reloadSections(sections, withRowAnimation: animation)
+  }
+  
+  override func reloadData() {
+    operations.append(.ReloadData)
+    super.reloadData()
+  }
+}
+
+class UITableViewDataSourceTests: XCTestCase {
+  var tableView: TestTableView!
+  var expectedTableView: TestTableView!
+  var array: DynamicArray<DynamicArray<Int>>!
+  var bond: UITableViewDataSourceBond<Void>!
+  override func setUp() {
+    array = DynamicArray([DynamicArray([1, 2]), DynamicArray([3, 4])])
+    let tableView = TestTableView()
+    self.tableView = tableView
+    tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "cellID")
+    expectedTableView = TestTableView()
+
+    bond = UITableViewDataSourceBond(tableView: tableView, disableAnimation: true)
+    array.map { array, sectionIndex in
+      array.map { int, index -> UITableViewCell in
+        return tableView.dequeueReusableCellWithIdentifier("cellID") as! UITableViewCell
+      }
+    } ->> bond
+    expectedTableView.reloadData() // `tableView` will get a `reloadData` when the bond is attached
+  }
+  
+  func testReload() {
+    array.setArray([])
+    expectedTableView.reloadData()
+    XCTAssertEqual(expectedTableView.operations, tableView.operations, "operation sequence did not match")
+  }
+}

--- a/BondTests/UITableViewDataSourceTests.swift
+++ b/BondTests/UITableViewDataSourceTests.swift
@@ -95,28 +95,27 @@ class TestTableView: UITableView {
 
 class UITableViewDataSourceTests: XCTestCase {
   var tableView: TestTableView!
-  var expectedTableView: TestTableView!
   var array: DynamicArray<DynamicArray<Int>>!
   var bond: UITableViewDataSourceBond<Void>!
+  var expectedOperations: [TableOperation]!
   override func setUp() {
     array = DynamicArray([DynamicArray([1, 2]), DynamicArray([3, 4])])
     let tableView = TestTableView()
     self.tableView = tableView
     tableView.registerClass(UITableViewCell.self, forCellReuseIdentifier: "cellID")
-    expectedTableView = TestTableView()
-
+    expectedOperations = []
     bond = UITableViewDataSourceBond(tableView: tableView, disableAnimation: true)
     array.map { array, sectionIndex in
       array.map { int, index -> UITableViewCell in
         return tableView.dequeueReusableCellWithIdentifier("cellID") as! UITableViewCell
       }
     } ->> bond
-    expectedTableView.reloadData() // `tableView` will get a `reloadData` when the bond is attached
+    expectedOperations.append(.ReloadData) // `tableView` will get a `reloadData` when the bond is attached
   }
   
   func testReload() {
     array.setArray([])
-    expectedTableView.reloadData()
-    XCTAssertEqual(expectedTableView.operations, tableView.operations, "operation sequence did not match")
+    expectedOperations.append(.ReloadData)
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
   }
 }


### PR DESCRIPTION
This makes it much easier when swapping out the contents of a given array (say, reloading the results for an updated search query) or when an upstream array has changed without details. I've blocked off access to the proxy arrays' `value` property entirely, for now. 

We could build a getter which would compute and return a value for the proxy array, but that could be unexpectedly expensive for users so I've left that for more thinking.