### PR TITLE
Table bond improvements

### DIFF
--- a/Bond/Bond+UITableView.swift
+++ b/Bond/Bond+UITableView.swift
@@ -175,6 +175,7 @@ public class UITableViewDataSourceBond<T>: ArrayBond<DynamicArray<UITableViewCel
   weak var tableView: UITableView?
   private var dataSource: TableViewDynamicArrayDataSource?
   private var sectionBonds: [UITableViewDataSourceSectionBond<Void>] = []
+  public let disableAnimation: Bool
   public weak var nextDataSource: UITableViewDataSource? {
     didSet(newValue) {
       dataSource?.nextDataSource = newValue
@@ -182,6 +183,7 @@ public class UITableViewDataSourceBond<T>: ArrayBond<DynamicArray<UITableViewCel
   }
   
   public init(tableView: UITableView, disableAnimation: Bool = false) {
+    self.disableAnimation = disableAnimation
     self.tableView = tableView
     super.init()
     
@@ -268,7 +270,7 @@ public class UITableViewDataSourceBond<T>: ArrayBond<DynamicArray<UITableViewCel
     if let dynamic = dynamic as? DynamicArray<DynamicArray<UITableViewCell>> {
       
       for section in 0..<dynamic.count {
-        let sectionBond = UITableViewDataSourceSectionBond<Void>(tableView: self.tableView, section: section)
+        let sectionBond = UITableViewDataSourceSectionBond<Void>(tableView: self.tableView, section: section, disableAnimation: disableAnimation)
         let sectionDynamic = dynamic[section]
         sectionDynamic.bindTo(sectionBond)
         sectionBonds.append(sectionBond)

--- a/BondTests/UITableViewDataSourceTests.swift
+++ b/BondTests/UITableViewDataSourceTests.swift
@@ -118,4 +118,42 @@ class UITableViewDataSourceTests: XCTestCase {
     expectedOperations.append(.ReloadData)
     XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
   }
+    
+  func testInsertARow() {
+    array[1].append(5)
+    expectedOperations.append(.InsertRows([NSIndexPath(forRow: 2, inSection: 1)]))
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testDeleteARow() {
+    array[1].removeLast()
+    expectedOperations.append(.DeleteRows([NSIndexPath(forRow: 1, inSection: 1)]))
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testReloadARow() {
+    array[1][1] = 5
+    expectedOperations.append(.ReloadRows([NSIndexPath(forRow: 1, inSection: 1)]))
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testInsertASection() {
+    array.insert(DynamicArray([7, 8, 9]), atIndex: 1)
+    expectedOperations.append(.InsertSections(NSIndexSet(index: 1)))
+    XCTAssertEqual(tableView.numberOfRowsInSection(1), 3, "wrong number of rows in new section")
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testDeleteASection() {
+    array.removeAtIndex(0)
+    expectedOperations.append(.DeleteSections(NSIndexSet(index: 0)))
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testReloadASection() {
+    array[1] = DynamicArray([5, 6, 7])
+    expectedOperations.append(.ReloadSections(NSIndexSet(index: 1)))
+    XCTAssertEqual(tableView.numberOfRowsInSection(1), 3, "wrong number of rows in reloaded section")
+    XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
 }


### PR DESCRIPTION
More tests for table view data source bond and fix bug where `disableAnimation` was no applied to sections that already existed when the bond was created.