### PR TITLE
Fix DynamicArray.append

### DIFF
--- a/Bond/Bond+Arrays.swift
+++ b/Bond/Bond+Arrays.swift
@@ -125,10 +125,10 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
   
   public func append(array: Array<T>) {
     if array.count > 0 {
-      let count = value.count
-      dispatchWillInsert(Array(count..<value.count))
+      let indices = Array(value.count..<value.count+array.count)
+      dispatchWillInsert(indices)
       value += array
-      dispatchDidInsert(Array(count..<value.count))
+      dispatchDidInsert(indices)
     }
   }
   
@@ -151,9 +151,10 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
   
   public func splice(array: Array<T>, atIndex i: Int) {
     if array.count > 0 {
-      dispatchWillInsert(Array(i..<i+array.count))
+      let indices = Array(i..<i+array.count)
+      dispatchWillInsert(indices)
       value.splice(array, atIndex: i)
-      dispatchDidInsert(Array(i..<i+array.count))
+      dispatchDidInsert(indices)
     }
   }
   
@@ -166,9 +167,10 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
   
   public func removeAll(keepCapacity: Bool) {
     let count = value.count
-    dispatchWillRemove(Array<Int>(0..<count))
+    let indices = Array(0..<count)
+    dispatchWillRemove(indices)
     value.removeAll(keepCapacity: keepCapacity)
-    dispatchDidRemove(Array<Int>(0..<count))
+    dispatchDidRemove(indices)
   }
   
   public subscript(index: Int) -> T {

--- a/Bond/Bond+Arrays.swift
+++ b/Bond/Bond+Arrays.swift
@@ -124,12 +124,7 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
   }
   
   public func append(array: Array<T>) {
-    if array.count > 0 {
-      let indices = Array(value.count..<value.count+array.count)
-      dispatchWillInsert(indices)
-      value += array
-      dispatchDidInsert(indices)
-    }
+	splice(array, atIndex: value.count)
   }
   
   public func removeLast() -> T {


### PR DESCRIPTION
- [x] Make `append` send the correct indices into `dispatchWillInsert:`
- [x] Optimize `removeAll` and `splice` by only creating the `indices` array once.