### PR TITLE
Fix TextField/TextView binding bug

### DIFF
--- a/Bond/Bond+UITextField.swift
+++ b/Bond/Bond+UITextField.swift
@@ -66,7 +66,7 @@ extension UITextField /*: Dynamical, Bondable */ {
       return (d as? Dynamic<String>)!
     } else {
       let d = TextFieldDynamic<String>(control: self)
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      let bond = Bond<String>() { [weak self] v in if let s = self { if s.text != v { s.text = v } } }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &textDynamicHandleUITextField, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UITextView.swift
+++ b/Bond/Bond+UITextView.swift
@@ -45,7 +45,7 @@ extension UITextView: Bondable {
         }
       }
       
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      let bond = Bond<String>() { [weak self] v in if let s = self { if s.text != v { s.text = v } } }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &textDynamicHandleUITextView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))


### PR DESCRIPTION
Fix TextField/TextView binding doesn't work well with languages which needs conversion.

## Before

Unsettled converting text is set back to TextField/TextView so more texts are set than input.

![before](https://cloud.githubusercontent.com/assets/536954/7708806/526c5c94-fe93-11e4-8c7e-46e3d33fbd32.gif)

## After

Only when text is different, update view.

![after](https://cloud.githubusercontent.com/assets/536954/7709066/6092219e-fe95-11e4-8763-8ad6fb14fad9.gif)
