### PR TITLE
Change text binding behavior for editing text

### DIFF
--- a/Bond/Bond+UITextField.swift
+++ b/Bond/Bond+UITextField.swift
@@ -66,7 +66,7 @@ extension UITextField /*: Dynamical, Bondable */ {
       return (d as? Dynamic<String>)!
     } else {
       let d = TextFieldDynamic<String>(control: self)
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      let bond = Bond<String>() { [weak self] v in if let s = self { if !s.isFirstResponder() { s.text = v } } }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &textDynamicHandleUITextField, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UITextView.swift
+++ b/Bond/Bond+UITextView.swift
@@ -45,7 +45,7 @@ extension UITextView: Bondable {
         }
       }
       
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      let bond = Bond<String>() { [weak self] v in if let s = self { if !s.isFirstResponder() { s.text = v } } }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &textDynamicHandleUITextView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))


### PR DESCRIPTION
This pull request is relating to https://github.com/SwiftBond/Bond/issues/64 issue. This puts more importance on user input  and simpler than https://github.com/SwiftBond/Bond/pull/61 . 

I use `isFirstResponder()` because UITextView doesn't have `editing` property. 