### PR TITLE
Add Bond delayed change propagation

### DIFF
--- a/Bond/Bond+Functional.swift
+++ b/Bond/Bond+Functional.swift
@@ -25,6 +25,8 @@
 //  THE SOFTWARE.
 //
 
+import QuartzCore
+
 // MARK: Map
 
 public func map<T, U>(dynamic: Dynamic<T>, f: T -> U) -> Dynamic<U> {
@@ -250,4 +252,8 @@ public func _throttle<T>(dynamic: Dynamic<T>, seconds: Double) -> Dynamic<T> {
   dynamic.bindTo(bond, fire: false)
   
   return dyn
+}
+
+public func throttle<T>(dynamic: Dynamic<T>, seconds: Double) -> Dynamic<T> {
+    return _throttle(dynamic, seconds)
 }

--- a/Bond/Bond+Functional.swift
+++ b/Bond/Bond+Functional.swift
@@ -216,9 +216,9 @@ public func any<T>(dynamics: [Dynamic<T>]) -> Dynamic<T> {
   return dyn
 }
 
-// MARK: Delay
+// MARK: Throttle
 
-public func _delay<T>(dynamic: Dynamic<T>, seconds: Double) -> Dynamic<T> {
+public func _throttle<T>(dynamic: Dynamic<T>, seconds: Double) -> Dynamic<T> {
   let dyn = InternalDynamic<T>()
   var timestamp: CFTimeInterval?
   var listener: (() -> Void)!

--- a/Bond/Bond.swift
+++ b/Bond/Bond.swift
@@ -252,6 +252,10 @@ public extension Dynamic
   public func skip(count: Int) -> Dynamic<T> {
     return _skip(self, count)
   }
+    
+  public func delay(seconds: Double) -> Dynamic<T> {
+    return _delay(self, seconds)
+  }
 }
 
 

--- a/Bond/Bond.swift
+++ b/Bond/Bond.swift
@@ -253,8 +253,8 @@ public extension Dynamic
     return _skip(self, count)
   }
     
-  public func delay(seconds: Double) -> Dynamic<T> {
-    return _delay(self, seconds)
+  public func throttle(seconds: Double) -> Dynamic<T> {
+    return _throttle(self, seconds)
   }
 }
 

--- a/README.md
+++ b/README.md
@@ -326,6 +326,14 @@ skip<T>(dynamic: Dynamic<T>, count: Int) -> Dynamic<T>
 
 You can use skip to create a Dynamic that'll not dispatch change events for `count` times. 
 
+#### Throttle
+
+```swift
+throttle<T>(dynamic: Dynamic<T>, seconds: Double) -> Dynamic<T>
+```
+
+Throttle function creates a new Dynamic that will propagate changes only after `seconds` delay. If any additional changes occurred while delaying, it will eat all previous changes and dispatch only the last one. _Note that all deferred changes will be dispatched on Main Thread!_
+
 #### Any
 
 ```swift


### PR DESCRIPTION
Recently i've implemented additional function and class method for delayed listeners calls and decided to share as it could be useful not only for me.

`delay(seconds: Double)` creates a new Dynamic that is bonded to its source Dynamic, but unlike existent functions, created Dynamic will not propagate changes immediately, it will dispatch changes after specified amount of time. If more than one changes occurs, created `Dynamic` will propagate only the last change.

In most cases such delayed code execution smell bad and should notify developer about app design issues. But on the other hand, there are cases, when we can't control amount of value changes. This is common case for UI components properties, for example, `contentOffset` changes of `UIScrollView` while scrolling, `text` property changes while user is typing in `UITextField`, etc. This function will help to reduce useless (in some cases) calls to listeners.

Small example. Imagine that you have some form with autocompletion (downloaded from network, without cache). You can't send network reques on every text changed event to grab new values as it will be redundant when user types quickly. With `delay` function optimized implementation could look as easy as this lines of code:
```swift
let bond = Bond<String> { 
	// perform network request with $0
}

queryTextField.dynText.delay(0.3) ->| bond
```
I haven't added any tests yet, will add if function is useful and should be merged.

What do you think about that?