### PR TITLE
Fix redundant dispatch

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -57,6 +57,7 @@
 		DCA979831A83C4F800DD4A30 /* BondTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BC01A7C217100A13B6B /* BondTests.swift */; };
 		DCA979841A83C52D00DD4A30 /* Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BCA1A7C21B600A13B6B /* Bond.swift */; };
 		DCA979851A83C52D00DD4A30 /* Bond+Arrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BCB1A7C21B600A13B6B /* Bond+Arrays.swift */; };
+		DFC184961B34193A00B3444E /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC184951B34193A00B3444E /* PerformanceTests.swift */; };
 		EC0301751AAA23C9004B3071 /* Bond+UICollectionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0301741AAA23C9004B3071 /* Bond+UICollectionView.swift */; };
 		EC0388991B0DD25700E32454 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
 		EC048D181AA238AF00E9794C /* Bond+Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC048D171AA238AF00E9794C /* Bond+Operators.swift */; };
@@ -169,6 +170,7 @@
 		CC581F751AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UITableViewDataSourceTests.swift; sourceTree = "<group>"; };
 		DCA979691A83C3A100DD4A30 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		DFC184951B34193A00B3444E /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		EC0301741AAA23C9004B3071 /* Bond+UICollectionView.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+UICollectionView.swift"; sourceTree = "<group>"; };
 		EC048D141AA2386A00E9794C /* Bond+Functional.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+Functional.swift"; sourceTree = "<group>"; };
 		EC048D171AA238AF00E9794C /* Bond+Operators.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+Operators.swift"; sourceTree = "<group>"; };
@@ -349,6 +351,7 @@
 				69491BD21A7C242900A13B6B /* DynamicTests.swift */,
 				ECD653A51A9B6BF30038A9AC /* FunctionalTests.swift */,
 				EC867F891AA73AD5007B4BC4 /* FoundationTests.swift */,
+				DFC184951B34193A00B3444E /* PerformanceTests.swift */,
 				EC6A5A841AB31954006071B6 /* ArrayTests.swift */,
 				900BFC041ADFC5AF002B4B6E /* AppKit */,
 				03A5DC961AAF9612007616B4 /* UIKit */,
@@ -695,6 +698,7 @@
 				03A5DCA81AAF995F007616B4 /* UITextFieldTests.swift in Sources */,
 				03A5DCA61AAF992F007616B4 /* UISwitchTests.swift in Sources */,
 				03A5DC9E1AAF97E9007616B4 /* UIProgressViewTests.swift in Sources */,
+				DFC184961B34193A00B3444E /* PerformanceTests.swift in Sources */,
 				EC7137E41AA25E9300CFC854 /* FunctionalTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/BondTests/BondTests.swift
+++ b/BondTests/BondTests.swift
@@ -61,4 +61,47 @@ class BondTests: XCTestCase {
     // assert: it should change again
     XCTAssertEqual(newValue, 1)
   }
+
+  func testEquatable() {
+    let bond1 = Bond<Int>({ value in })
+    let bond2 = Bond<Int>({ value in })
+
+    XCTAssert(bond1 == bond1 && bond2 == bond2, "Bonds should be equal if they are identical")
+    XCTAssert(bond1 != bond2, "Bonds should not be equal if they are not identical")
+  }
+
+  func testBoxEquatable() {
+    let bond1 = Bond<Int>({ value in })
+    let bond2 = Bond<Int>({ value in })
+
+    // Referencing to the same bond.
+    let bondBox1 = BondBox(bond1)
+    let bondBox2 = BondBox(bond1)
+
+    // Referencing to other bond.
+    let bondBox3 = BondBox(bond2)
+
+    XCTAssert(bondBox1 == bondBox2, "BondBoxes should be equal if wrapped Bonds are identical")
+    XCTAssert(bondBox1 != bondBox3 && bondBox2 != bondBox3, "BondBoxes should not be equal if wrapped Bonds are not identical")
+  }
+
+  func testBoxEquatableIfNilled() {
+    var bond: Bond? = Bond<Int>({ value in })
+
+    // Referencing to the same bond.
+    let bondBox1 = BondBox(bond!)
+    let bondBox2 = BondBox(bond!)
+
+    // Nil out the bond.
+    bond = nil
+
+    XCTAssert(bondBox1 == bondBox2, "BondBoxes that used to wrap the same Bond should be marked equal even if the wrapped Bond is lost")
+  }
+
+  func testHashable() {
+    let bond = Bond<Int>({ value in })
+    let ptrHash = unsafeAddressOf(bond).hashValue
+
+    XCTAssert(bond.hashValue == ptrHash, "Each Bond should have draw its hash from memory address")
+  }
 }

--- a/BondTests/DynamicTests.swift
+++ b/BondTests/DynamicTests.swift
@@ -18,7 +18,7 @@ class DynamicTests: XCTestCase {
     let intBond = Bond<Int>({ value in
       newValue = value
     })
-    dynamicInt.bonds.append(BondBox<Int>(intBond))
+    dynamicInt.bonds.insert(BondBox<Int>(intBond))
     
     // act: change the value to 1
     dynamicInt.value = 1
@@ -38,7 +38,7 @@ class DynamicTests: XCTestCase {
         newValues[i] = value
       })
       bonds.append(bond)
-      dynamicInt.bonds.append(BondBox<Int>(bond))
+      dynamicInt.bonds.insert(BondBox<Int>(bond))
     }
     
     // act: change the value to 1
@@ -48,6 +48,26 @@ class DynamicTests: XCTestCase {
     for i in 0..<10 {
       XCTAssertEqual(newValues[i], 1, "New value at index \(i) is incorrect")
     }
+  }
+
+  func testConsecutiveBonding() {
+    let dynamicInt = Dynamic<Int>(0)
+
+    var counter = 0
+    let intBond = Bond<Int>({ value in
+      counter++
+    })
+
+    // strong reference bonds to avoid premature dealloc
+    dynamicInt ->| intBond
+    dynamicInt ->| intBond
+    dynamicInt ->| intBond
+
+    // act: change the value to 1
+    dynamicInt.value = 1
+
+    // assert that all the listeners were notified
+    XCTAssert(counter == 1, "Bond called more than once")
   }
   
   func testWeakBondRemoval() {

--- a/BondTests/PerformanceTests.swift
+++ b/BondTests/PerformanceTests.swift
@@ -51,7 +51,7 @@ class DynamicPerformanceTests: XCTestCase {
       let dynamicInt = Dynamic<Int>(0)
       let intBond = Bond<Int>({ value in })
 
-      dynamicInt.bonds.append(BondBox<Int>(intBond))
+      dynamicInt.bonds.insert(BondBox<Int>(intBond))
 
       // Test
       self.startMeasuring()

--- a/BondTests/PerformanceTests.swift
+++ b/BondTests/PerformanceTests.swift
@@ -1,0 +1,64 @@
+//
+//  PerformanceTests.swift
+//  Bond
+//
+//  Created by Ivan Moskalev on 19.06.15.
+//  Copyright (c) 2015 Bond. All rights reserved.
+//
+
+import XCTest
+import Bond
+
+class BondPerformanceTests: XCTestCase {
+
+  func testBindPerformance() {
+    let dynamicInt = Dynamic<Int>(0)
+    let intBond = Bond<Int>({ value in })
+
+    self.measureBlock {
+      dynamicInt.bindTo(intBond)
+    }
+  }
+
+  func testUnbindAllPerformance() {
+    self.measureMetrics(self.dynamicType.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+
+      // Setup
+      let dynamics = Array(count: 100, repeatedValue: Dynamic<Int>(0))
+      let intBond = Bond<Int>({ value in })
+
+      for dynamic in dynamics {
+        dynamic ->| intBond
+      }
+
+      // Test
+      self.startMeasuring()
+      intBond.unbindAll()
+      self.stopMeasuring()
+
+    }
+  }
+
+}
+
+
+class DynamicPerformanceTests: XCTestCase {
+
+  func testDispatchPerformance() {
+    self.measureMetrics(self.dynamicType.defaultPerformanceMetrics(), automaticallyStartMeasuring: false) { () -> Void in
+
+      // Setup
+      let dynamicInt = Dynamic<Int>(0)
+      let intBond = Bond<Int>({ value in })
+
+      dynamicInt.bonds.append(BondBox<Int>(intBond))
+
+      // Test
+      self.startMeasuring()
+      dynamicInt.value = 1
+      self.stopMeasuring()
+
+    }
+  }
+
+}


### PR DESCRIPTION
Working on issue #78 

- Made `Bond` Equatable on the basis of memory address
- `BondBox` infers equality from the `Bond` it wraps
- Ref-ing `Bonds` in `Dynamic` with a `Set` (fixes redundant dispatch)
- Added performance tests for relevant functions

Before:
```
Test Case '-[BondTests.BondPerformanceTests testBindPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 124.554%, values: [0.000041, 0.000010, 0.000011, 0.000003, 0.000006, 0.000003, 0.000003, 0.000002, 0.000006, 0.000004], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[BondTests.BondPerformanceTests testUnbindAllPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 12.268%, values: [0.000357, 0.000256, 0.000254, 0.000251, 0.000250, 0.000249, 0.000249, 0.000248, 0.000249, 0.000249], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[BondTests.DynamicPerformanceTests testDispatchPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 52.782%, values: [0.000034, 0.000014, 0.000012, 0.000011, 0.000011, 0.000011, 0.000010, 0.000011, 0.000011, 0.000010], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
```

After:
```
Test Case '-[BondTests.BondPerformanceTests testBindPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 88.803%, values: [0.000036, 0.000011, 0.000010, 0.000007, 0.000008, 0.000006, 0.000006, 0.000005, 0.000007, 0.000005], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[BondTests.BondPerformanceTests testUnbindAllPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 10.071%, values: [0.000258, 0.000194, 0.000191, 0.000191, 0.000191, 0.000189, 0.000190, 0.000189, 0.000202, 0.000194], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
Test Case '-[BondTests.DynamicPerformanceTests testDispatchPerformance]' measured [Time, seconds] average: 0.000, relative standard deviation: 57.606%, values: [0.000019, 0.000008, 0.000006, 0.000007, 0.000015, 0.000006, 0.000005, 0.000005, 0.000005, 0.000004], performanceMetricID:com.apple.XCTPerformanceMetric_WallClockTime, baselineName: "", baselineAverage: , maxPercentRegression: 10.000%, maxPercentRelativeStandardDeviation: 10.000%, maxRegression: 0.100, maxStandardDeviation: 0.100
```