### PR TITLE
#83: Implement dynamic(...) function

### DIFF
--- a/Bond/Bond+Functional.swift
+++ b/Bond/Bond+Functional.swift
@@ -271,3 +271,24 @@ public func _deliver<T>(dynamic: Dynamic<T>, on queue: dispatch_queue_t) -> Dyna
 public func deliver<T>(dynamic: Dynamic<T>, on queue: dispatch_queue_t) -> Dynamic<T> {
   return _deliver(dynamic, on: queue)
 }
+
+// MARK: Distinct
+
+internal func _distinct<T: Equatable>(dynamic: Dynamic<T>) -> Dynamic<T> {
+  let dyn = InternalDynamic<T>(dynamic.value)
+
+  let bond = Bond<T> { [weak dyn] v in
+    if v != dyn?.value {
+      dyn?.value = v
+    }
+  }
+
+  dyn.retain(bond)
+  dynamic.bindTo(bond, fire: false)
+
+  return dyn
+}
+
+public func distinct<T: Equatable>(dynamic: Dynamic<T>) -> Dynamic<T> {
+  return _distinct(dynamic)
+}

--- a/BondTests/FunctionalTests.swift
+++ b/BondTests/FunctionalTests.swift
@@ -214,4 +214,23 @@ class ReduceTests: XCTestCase {
     
     waitForExpectationsWithTimeout(1, handler: nil)
   }
+
+  func testDistinct() {
+    var values = [Int]()
+    let d1 = Dynamic<Int>(0)
+    let bond = Bond<Int>() { v in values.append(v) }
+
+    let distinctD1 = distinct(d1)
+
+    distinctD1 ->> bond
+
+    d1.value = 1
+    d1.value = 2
+    d1.value = 2
+    d1.value = 3
+    d1.value = 3
+    d1.value = 3
+
+    XCTAssert(values == [0, 1, 2, 3], "Values should equal [0, 1, 2, 3] instead of \(values)")
+  }
 }


### PR DESCRIPTION
Implemented the module-level function that takes an `Equatatble`-constrained `Dynamic` as an argument. So far having trouble with implementing it as an operator – it seems to be impossible to add a member function that supports a narrower type than its parent class :(

Maybe anyone knows how this can be achieved? That would be fantastic! 