### PR TITLE
Adding 'dynTextColor' variable to UILabel

### DIFF
--- a/Bond/Bond+UILabel.swift
+++ b/Bond/Bond+UILabel.swift
@@ -29,35 +29,49 @@ import UIKit
 
 private var textDynamicHandleUILabel: UInt8 = 0;
 private var attributedTextDynamicHandleUILabel: UInt8 = 0;
+private var textColorDynamicHandleUILabel: UInt8 = 0;
 
 extension UILabel: Bondable {
-  public var dynText: Dynamic<String> {
-    if let d: AnyObject = objc_getAssociatedObject(self, &textDynamicHandleUILabel) {
-      return (d as? Dynamic<String>)!
-    } else {
-      let d = InternalDynamic<String>(self.text ?? "")
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
-      d.bindTo(bond, fire: false, strongly: false)
-      d.retain(bond)
-      objc_setAssociatedObject(self, &textDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
-      return d
+    public var dynText: Dynamic<String> {
+        if let d: AnyObject = objc_getAssociatedObject(self, &textDynamicHandleUILabel) {
+            return (d as? Dynamic<String>)!
+        } else {
+            let d = InternalDynamic<String>(self.text ?? "")
+            let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+            d.bindTo(bond, fire: false, strongly: false)
+            d.retain(bond)
+            objc_setAssociatedObject(self, &textDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            return d
+        }
     }
-  }
-  
-  public var dynAttributedText: Dynamic<NSAttributedString> {
-    if let d: AnyObject = objc_getAssociatedObject(self, &attributedTextDynamicHandleUILabel) {
-      return (d as? Dynamic<NSAttributedString>)!
-    } else {
-      let d = InternalDynamic<NSAttributedString>(self.attributedText ?? NSAttributedString(string: ""))
-      let bond = Bond<NSAttributedString>() { [weak self] v in if let s = self { s.attributedText = v } }
-      d.bindTo(bond, fire: false, strongly: false)
-      d.retain(bond)
-      objc_setAssociatedObject(self, &attributedTextDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
-      return d
+    
+    public var dynAttributedText: Dynamic<NSAttributedString> {
+        if let d: AnyObject = objc_getAssociatedObject(self, &attributedTextDynamicHandleUILabel) {
+            return (d as? Dynamic<NSAttributedString>)!
+        } else {
+            let d = InternalDynamic<NSAttributedString>(self.attributedText ?? NSAttributedString(string: ""))
+            let bond = Bond<NSAttributedString>() { [weak self] v in if let s = self { s.attributedText = v } }
+            d.bindTo(bond, fire: false, strongly: false)
+            d.retain(bond)
+            objc_setAssociatedObject(self, &attributedTextDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            return d
+        }
     }
-  }
-  
-  public var designatedBond: Bond<String> {
-    return self.dynText.valueBond
-  }
+    
+    public var dynTextColor: Dynamic<UIColor> {
+        if let d: AnyObject = objc_getAssociatedObject(self, &textColorDynamicHandleUILabel) {
+            return (d as? Dynamic<UIColor>)!
+        } else {
+            let d = InternalDynamic<UIColor>(self.textColor ?? UIColor.clearColor())
+            let bond = Bond<UIColor>() { [weak self] v in if let s = self { s.textColor = v } }
+            d.bindTo(bond, fire: false, strongly: false)
+            d.retain(bond)
+            objc_setAssociatedObject(self, &textColorDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+            return d
+        }
+    }
+    
+    public var designatedBond: Bond<String> {
+        return self.dynText.valueBond
+    }
 }

--- a/Bond/Bond+UILabel.swift
+++ b/Bond/Bond+UILabel.swift
@@ -32,46 +32,46 @@ private var attributedTextDynamicHandleUILabel: UInt8 = 0;
 private var textColorDynamicHandleUILabel: UInt8 = 0;
 
 extension UILabel: Bondable {
-    public var dynText: Dynamic<String> {
-        if let d: AnyObject = objc_getAssociatedObject(self, &textDynamicHandleUILabel) {
-            return (d as? Dynamic<String>)!
-        } else {
-            let d = InternalDynamic<String>(self.text ?? "")
-            let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
-            d.bindTo(bond, fire: false, strongly: false)
-            d.retain(bond)
-            objc_setAssociatedObject(self, &textDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
-            return d
-        }
+  public var dynText: Dynamic<String> {
+    if let d: AnyObject = objc_getAssociatedObject(self, &textDynamicHandleUILabel) {
+      return (d as? Dynamic<String>)!
+    } else {
+      let d = InternalDynamic<String>(self.text ?? "")
+      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      d.bindTo(bond, fire: false, strongly: false)
+      d.retain(bond)
+      objc_setAssociatedObject(self, &textDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+      return d
     }
+  }
     
-    public var dynAttributedText: Dynamic<NSAttributedString> {
-        if let d: AnyObject = objc_getAssociatedObject(self, &attributedTextDynamicHandleUILabel) {
-            return (d as? Dynamic<NSAttributedString>)!
-        } else {
-            let d = InternalDynamic<NSAttributedString>(self.attributedText ?? NSAttributedString(string: ""))
-            let bond = Bond<NSAttributedString>() { [weak self] v in if let s = self { s.attributedText = v } }
-            d.bindTo(bond, fire: false, strongly: false)
-            d.retain(bond)
-            objc_setAssociatedObject(self, &attributedTextDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
-            return d
-        }
+  public var dynAttributedText: Dynamic<NSAttributedString> {
+    if let d: AnyObject = objc_getAssociatedObject(self, &attributedTextDynamicHandleUILabel) {
+      return (d as? Dynamic<NSAttributedString>)!
+    } else {
+      let d = InternalDynamic<NSAttributedString>(self.attributedText ?? NSAttributedString(string: ""))
+      let bond = Bond<NSAttributedString>() { [weak self] v in if let s = self { s.attributedText = v } }
+      d.bindTo(bond, fire: false, strongly: false)
+      d.retain(bond)
+      objc_setAssociatedObject(self, &attributedTextDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+      return d
     }
+  }
     
-    public var dynTextColor: Dynamic<UIColor> {
-        if let d: AnyObject = objc_getAssociatedObject(self, &textColorDynamicHandleUILabel) {
-            return (d as? Dynamic<UIColor>)!
-        } else {
-            let d = InternalDynamic<UIColor>(self.textColor ?? UIColor.clearColor())
-            let bond = Bond<UIColor>() { [weak self] v in if let s = self { s.textColor = v } }
-            d.bindTo(bond, fire: false, strongly: false)
-            d.retain(bond)
-            objc_setAssociatedObject(self, &textColorDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
-            return d
-        }
+  public var dynTextColor: Dynamic<UIColor> {
+    if let d: AnyObject = objc_getAssociatedObject(self, &textColorDynamicHandleUILabel) {
+      return (d as? Dynamic<UIColor>)!
+    } else {
+      let d = InternalDynamic<UIColor>(self.textColor ?? UIColor.blackColor())
+      let bond = Bond<UIColor>() { [weak self] v in if let s = self { s.textColor = v } }
+      d.bindTo(bond, fire: false, strongly: false)
+      d.retain(bond)
+      objc_setAssociatedObject(self, &textColorDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
+      return d
     }
+  }
     
-    public var designatedBond: Bond<String> {
-        return self.dynText.valueBond
-    }
+  public var designatedBond: Bond<String> {
+    return self.dynText.valueBond
+  }
 }

--- a/BondTests/UILabelTests.swift
+++ b/BondTests/UILabelTests.swift
@@ -12,45 +12,45 @@ import Bond
 
 class UILabelTests: XCTestCase {
     
-    func testUILabelBond() {
-        var dynamicDriver = Dynamic<String>("b")
-        let label = UILabel()
+  func testUILabelBond() {
+    var dynamicDriver = Dynamic<String>("b")
+    let label = UILabel()
         
-        label.text = "a"
-        XCTAssert(label.text == "a", "Initial value")
+    label.text = "a"
+    XCTAssert(label.text == "a", "Initial value")
         
-        dynamicDriver ->> label.designatedBond
-        XCTAssert(label.text == "b", "Value after binding")
+    dynamicDriver ->> label.designatedBond
+    XCTAssert(label.text == "b", "Value after binding")
         
-        dynamicDriver.value = "c"
-        XCTAssert(label.text == "c", "Value after dynamic change")
-    }
+    dynamicDriver.value = "c"
+    XCTAssert(label.text == "c", "Value after dynamic change")
+  }
     
-    func testUILabelAttributedTextBond() {
-        var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
-        let label = UILabel()
+  func testUILabelAttributedTextBond() {
+    var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
+    let label = UILabel()
         
-        label.text = "a"
-        XCTAssert(label.text == "a", "Initial value")
+    label.text = "a"
+    XCTAssert(label.text == "a", "Initial value")
         
-        dynamicDriver ->> label.dynAttributedText
-        XCTAssert(label.attributedText.string == "b", "Value after binding")
+    dynamicDriver ->> label.dynAttributedText
+    XCTAssert(label.attributedText.string == "b", "Value after binding")
         
-        dynamicDriver.value = NSAttributedString(string: "c")
-        XCTAssert(label.attributedText.string == "c", "Value after dynamic change")
-    }
+    dynamicDriver.value = NSAttributedString(string: "c")
+    XCTAssert(label.attributedText.string == "c", "Value after dynamic change")
+  }
     
-    func testUILabelTextColorBond() {
-        var dynamicDriver = Dynamic<UIColor>(UIColor.blackColor())
-        var label = UILabel()
+  func testUILabelTextColorBond() {
+    var dynamicDriver = Dynamic<UIColor>(UIColor.blackColor())
+    var label = UILabel()
         
-        label.textColor = UIColor.redColor()
-        XCTAssert(label.textColor == UIColor.redColor(), "Initial Value")
+    label.textColor = UIColor.redColor()
+    XCTAssert(label.textColor == UIColor.redColor(), "Initial Value")
         
-        dynamicDriver ->> label.dynTextColor
-        XCTAssert(label.textColor == UIColor.blackColor(), "Value after binding")
+    dynamicDriver ->> label.dynTextColor
+    XCTAssert(label.textColor == UIColor.blackColor(), "Value after binding")
         
-        dynamicDriver.value = UIColor.blueColor()
-        XCTAssert(label.textColor == UIColor.blueColor(), "Value after dynamic change")
-    }
+    dynamicDriver.value = UIColor.blueColor()
+    XCTAssert(label.textColor == UIColor.blueColor(), "Value after dynamic change")
+  }
 }

--- a/BondTests/UILabelTests.swift
+++ b/BondTests/UILabelTests.swift
@@ -11,32 +11,46 @@ import XCTest
 import Bond
 
 class UILabelTests: XCTestCase {
-
-  func testUILabelBond() {
-    var dynamicDriver = Dynamic<String>("b")
-    let label = UILabel()
     
-    label.text = "a"
-    XCTAssert(label.text == "a", "Initial value")
+    func testUILabelBond() {
+        var dynamicDriver = Dynamic<String>("b")
+        let label = UILabel()
+        
+        label.text = "a"
+        XCTAssert(label.text == "a", "Initial value")
+        
+        dynamicDriver ->> label.designatedBond
+        XCTAssert(label.text == "b", "Value after binding")
+        
+        dynamicDriver.value = "c"
+        XCTAssert(label.text == "c", "Value after dynamic change")
+    }
     
-    dynamicDriver ->> label.designatedBond
-    XCTAssert(label.text == "b", "Value after binding")
+    func testUILabelAttributedTextBond() {
+        var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
+        let label = UILabel()
+        
+        label.text = "a"
+        XCTAssert(label.text == "a", "Initial value")
+        
+        dynamicDriver ->> label.dynAttributedText
+        XCTAssert(label.attributedText.string == "b", "Value after binding")
+        
+        dynamicDriver.value = NSAttributedString(string: "c")
+        XCTAssert(label.attributedText.string == "c", "Value after dynamic change")
+    }
     
-    dynamicDriver.value = "c"
-    XCTAssert(label.text == "c", "Value after dynamic change")
-  }
-  
-  func testUILabelAttributedTextBond() {
-    var dynamicDriver = Dynamic<NSAttributedString>(NSAttributedString(string: "b"))
-    let label = UILabel()
-    
-    label.text = "a"
-    XCTAssert(label.text == "a", "Initial value")
-    
-    dynamicDriver ->> label.dynAttributedText
-    XCTAssert(label.attributedText.string == "b", "Value after binding")
-    
-    dynamicDriver.value = NSAttributedString(string: "c")
-    XCTAssert(label.attributedText.string == "c", "Value after dynamic change")
-  }
+    func testUILabelTextColorBond() {
+        var dynamicDriver = Dynamic<UIColor>(UIColor.blackColor())
+        var label = UILabel()
+        
+        label.textColor = UIColor.redColor()
+        XCTAssert(label.textColor == UIColor.redColor(), "Initial Value")
+        
+        dynamicDriver ->> label.dynTextColor
+        XCTAssert(label.textColor == UIColor.blackColor(), "Value after binding")
+        
+        dynamicDriver.value = UIColor.blueColor()
+        XCTAssert(label.textColor == UIColor.blueColor(), "Value after dynamic change")
+    }
 }

--- a/README.md
+++ b/README.md
@@ -229,7 +229,7 @@ Following table lists all available Dynamics of UIKit objects:
 |----------------|---------------------------------------------------------|-----------------|
 | UIView         | dynAlpha <br> dynHidden <br> dynBackgroundColor         | --              |
 | UISlider       | dynValue                                                | dynValue        |
-| UILabel        | dynText <br> dynAttributedText                          | dynText         |
+| UILabel        | dynText <br> dynAttributedText <br> dynTextColor        | dynText         |
 | UIProgressView | dynProgress                                             | dynProgress     |
 | UIImageView    | dynImage                                                | dynImage        |
 | UIButton       | dynEnabled <br> dynTitle <br> dynImageForNormalState    | dynEnabled      |


### PR DESCRIPTION
I had need of dynamically changing the text color of an UILabel and I find dealing with NSAttributedText to be clumsy. This commit allows the "textColor" attribute of the UILabel to be modified in the same way as the "backgroundColor" attribute of the UIView.

I added the appropriate code and tests, following the style of the already written code. Also modified the Readme file to include "dynTextColor" in the table which displays the available dyn* variables

Please go easy on me, this is my first commit on an open source project. I am intentionally making it a small change however I may develop more in the future.