### PR TITLE
Add support for observable of optional values

### DIFF
--- a/Bond/Bond+Foundation.swift
+++ b/Bond/Bond+Foundation.swift
@@ -95,6 +95,14 @@ public func dynamicObservableFor<T>(object: NSObject, #keyPath: String, #default
   return dynamic
 }
 
+public func dynamicOptionalObservableFor<T>(object: NSObject, #keyPath: String, defaultValue: T? = nil) -> Dynamic<T?> {
+    return dynamicObservableFor(object, keyPath: keyPath, from: { (value: AnyObject?) -> T? in
+        return value as? T
+        }, to: { (value: T?) -> AnyObject? in
+            return value as? AnyObject
+    })
+}
+
 public func dynamicObservableFor<T>(object: NSObject, #keyPath: String, #from: AnyObject? -> T, #to: T -> AnyObject?) -> Dynamic<T> {
   let keyPathValue: AnyObject? = object.valueForKeyPath(keyPath)
   let dynamic = InternalDynamic(from(keyPathValue))

--- a/BondTests/FoundationTests.swift
+++ b/BondTests/FoundationTests.swift
@@ -12,6 +12,7 @@ import Bond
 @objc class User: NSObject {
   dynamic var name: NSString?
   dynamic var height: NSNumber = NSNumber(float: 0.0)
+  dynamic var date: NSDate?
   
   init(name: NSString?) {
     self.name = name
@@ -77,5 +78,19 @@ class FoundationTests: XCTestCase {
     
     height.value = 7.1
     XCTAssert(abs(user.height.floatValue - 7.1) < 0.0001, "Value after dynamic change.")
+  }
+    
+  func testKVO5() {
+    let user = User(name: nil)
+    let dynamic: Dynamic<NSDate?> = dynamicOptionalObservableFor(user, keyPath: "date")
+    
+    XCTAssert(dynamic.value == nil, "Value after initialization.")
+
+    let date = NSDate()
+    user.date = date
+    XCTAssert(user.date == date, "Value after property change.")
+
+    user.date = nil
+    XCTAssert(dynamic.value == nil, "Value after property change.")
   }
 }


### PR DESCRIPTION
Otherwise swift will encounter problem casting and crash when observing
types such as `Dynamic<NSDate?>` or `Dynamic<String?>`