### PR TITLE
Modified all declarations of dynamic variables in the UIView extensio…

### DIFF
--- a/Bond/Bond+CALayer.swift
+++ b/Bond/Bond+CALayer.swift
@@ -43,10 +43,8 @@ extension CALayer: Bondable, Dynamical {
             return (d as? Dynamic<CGColor!>)!
         } else {
             let d = InternalDynamic<CGColor!>(self.backgroundColor)
-            let bond = Bond<CGColor!>() { [weak self] v in
-                if let s = self {
-                    s.backgroundColor = v
-                }
+            let bond = Bond<CGColor!>() { [weak self] in
+                self?.backgroundColor = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)
@@ -61,10 +59,8 @@ extension CALayer: Bondable, Dynamical {
             return (d as? Dynamic<AnyObject!>)!
         } else {
             let d = InternalDynamic<AnyObject!>(self.contents)
-            let bond = Bond<AnyObject!>() { [weak self] v in
-                if let s = self {
-                    s.contents = v
-                }
+            let bond = Bond<AnyObject!>() { [weak self] in
+                self?.contents = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)
@@ -79,10 +75,8 @@ extension CALayer: Bondable, Dynamical {
             return (d as? Dynamic<Float>)!
         } else {
             let d = InternalDynamic<Float>(self.opacity)
-            let bond = Bond<Float>() { [weak self] v in
-                if let s = self {
-                    s.opacity = v
-                }
+            let bond = Bond<Float>() { [weak self] in
+                self?.opacity = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSButton.swift
+++ b/Bond/Bond+NSButton.swift
@@ -41,10 +41,8 @@ extension NSButton: Bondable, Dynamical {
             return (d as? Dynamic<Int>)!
         } else {
             let d = InternalDynamic<Int>(self.state)
-            let bond = Bond<Int>() { [weak self] v in
-                if let s = self {
-                    s.state = v
-                }
+            let bond = Bond<Int>() { [weak self] in
+                self?.state = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSColorWell.swift
+++ b/Bond/Bond+NSColorWell.swift
@@ -41,10 +41,8 @@ extension NSColorWell: Bondable, Dynamical {
             return (d as? Dynamic<NSColor>)!
         } else {
             let d = InternalDynamic<NSColor>(self.color)
-            let bond = Bond<NSColor>() { [weak self] v in
-                if let s = self {
-                    s.color = v
-                }
+            let bond = Bond<NSColor>() { [weak self] in
+                self?.color = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSControl.swift
+++ b/Bond/Bond+NSControl.swift
@@ -56,10 +56,8 @@ extension NSControl {
             return (d as? Dynamic<Bool>)!
         } else {
             let d = InternalDynamic<Bool>(self.enabled)
-            let bond = Bond<Bool>() { [weak self] v in
-                if let s = self {
-                    s.enabled = v
-                }
+            let bond = Bond<Bool>() { [weak self] in
+                self?.enabled = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSImageView.swift
+++ b/Bond/Bond+NSImageView.swift
@@ -41,10 +41,8 @@ extension NSImageView: Bondable, Dynamical {
             return (d as? Dynamic<NSImage?>)!
         } else {
             let d = InternalDynamic<NSImage?>(self.image)
-            let bond = Bond<NSImage?>() { [weak self] v in
-                if let s = self {
-                    s.image = v
-                }
+            let bond = Bond<NSImage?>() { [weak self] in
+                self?.image = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSMenuItem.swift
+++ b/Bond/Bond+NSMenuItem.swift
@@ -42,10 +42,8 @@ extension NSMenuItem: Bondable, Dynamical {
             return (d as? Dynamic<Bool>)!
         } else {
             let d = InternalDynamic<Bool>(self.enabled)
-            let bond = Bond<Bool>() { [weak self] v in
-                if let s = self {
-                    s.enabled = v
-                }
+            let bond = Bond<Bool>() { [weak self] in
+                self?.enabled = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)
@@ -60,10 +58,8 @@ extension NSMenuItem: Bondable, Dynamical {
             return (d as? Dynamic<Int>)!
         } else {
             let d = InternalDynamic<Int>(self.state)
-            let bond = Bond<Int>() { [weak self] v in
-                if let s = self {
-                    s.state = v
-                }
+            let bond = Bond<Int>() { [weak self] in
+                self?.state = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSStatusBarButton.swift
+++ b/Bond/Bond+NSStatusBarButton.swift
@@ -33,10 +33,8 @@ extension NSStatusBarButton {
             return (d as? Dynamic<Bool>)!
         } else {
             let d = InternalDynamic<Bool>(self.appearsDisabled)
-            let bond = Bond<Bool>() { [weak self] v in
-                if let s = self {
-                    s.appearsDisabled = v
-                }
+            let bond = Bond<Bool>() { [weak self] in
+                self?.appearsDisabled = $0
             }
 
             d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+NSTextField.swift
+++ b/Bond/Bond+NSTextField.swift
@@ -76,9 +76,9 @@ extension NSTextField: Dynamical, Bondable {
         } else {
             let d = TextFieldDynamic<String>(control: self)
           
-            let bond = Bond<String>() { [weak self, weak d] v in
-                if let s = self, d = d where !d.updatingFromSelf {
-                    s.stringValue = v
+            let bond = Bond<String>() { [weak self, weak d] in
+                if let d = d where !d.updatingFromSelf {
+                    self?.stringValue = $0
                 }
             }
           

--- a/Bond/Bond+NSTextView.swift
+++ b/Bond/Bond+NSTextView.swift
@@ -49,9 +49,9 @@ extension NSTextView: Dynamical, Bondable {
                 }
             }
 
-            let bond = Bond<String>() { [weak d] v in // NSTextView cannot be referenced weakly
+            let bond = Bond<String>() { [weak d] in // NSTextView cannot be referenced weakly
                 if let d = d where !d.updatingFromSelf {
-                    self.string = v
+                    self.string = $0
                 }
             }
           

--- a/Bond/Bond+UIActivityIndicatorView.swift
+++ b/Bond/Bond+UIActivityIndicatorView.swift
@@ -36,13 +36,11 @@ extension UIActivityIndicatorView: Bondable {
       return (d as? Dynamic<Bool>)!
     } else {
       let d = InternalDynamic<Bool>(self.isAnimating())
-      let bond = Bond<Bool>() { [weak self] v in
-        if let s = self {
-          if v {
-            s.startAnimating()
-          } else {
-            s.stopAnimating()
-          }
+      let bond = Bond<Bool>() { [weak self] in
+        if $0 {
+          self?.startAnimating()
+        } else {
+          self?.stopAnimating()
         }
       }
       d.bindTo(bond, fire: false, strongly: false)

--- a/Bond/Bond+UIBarItem.swift
+++ b/Bond/Bond+UIBarItem.swift
@@ -38,7 +38,7 @@ extension UIBarItem: Bondable {
       return (d as? Dynamic<Bool>)!
     } else {
       let d = InternalDynamic<Bool>(self.enabled)
-      let bond = Bond<Bool>() { [weak self] v in if let s = self { s.enabled = v } }
+      let bond = Bond<Bool>() { [weak self] in self?.enabled = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &enabledDynamicHandleUIBarItem, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -51,7 +51,7 @@ extension UIBarItem: Bondable {
       return (d as? Dynamic<String>)!
     } else {
       let d = InternalDynamic<String>(self.title ?? "")
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.title = v } }
+      let bond = Bond<String>() { [weak self] in self?.title = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &titleDynamicHandleUIBarItem, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -64,7 +64,7 @@ extension UIBarItem: Bondable {
       return (d as? Dynamic<UIImage?>)!
     } else {
       let d = InternalDynamic<UIImage?>(self.image)
-      let bond = Bond<UIImage?>() { [weak self] img in if let s = self { s.image = img } }
+      let bond = Bond<UIImage?>() { [weak self] in self?.image = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &imageDynamicHandleUIBarItem, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UIButton.swift
+++ b/Bond/Bond+UIButton.swift
@@ -96,7 +96,7 @@ extension UIButton /*: Dynamical, Bondable */ {
       return (d as? Dynamic<Bool>)!
     } else {
       let d = InternalDynamic<Bool>(self.enabled)
-      let bond = Bond<Bool>() { [weak self] v in if let s = self { s.enabled = v } }
+      let bond = Bond<Bool>() { [weak self] in self?.enabled = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &enabledDynamicHandleUIButton, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -109,7 +109,7 @@ extension UIButton /*: Dynamical, Bondable */ {
       return (d as? Dynamic<String>)!
     } else {
       let d = InternalDynamic<String>(self.titleLabel?.text ?? "")
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.setTitle(v, forState: .Normal) } }
+      let bond = Bond<String>() { [weak self] in self?.setTitle($0, forState: .Normal) }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &titleDynamicHandleUIButton, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -122,7 +122,7 @@ extension UIButton /*: Dynamical, Bondable */ {
       return (d as? Dynamic<UIImage?>)!
     } else {
       let d = InternalDynamic<UIImage?>(self.imageForState(.Normal))
-      let bond = Bond<UIImage?>() { [weak self] img in if let s = self { s.setImage(img, forState: .Normal) } }
+      let bond = Bond<UIImage?>() { [weak self] in self?.setImage($0, forState: .Normal) }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &imageForNormalStateDynamicHandleUIButton, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UIDatePicker.swift
+++ b/Bond/Bond+UIDatePicker.swift
@@ -70,9 +70,9 @@ extension UIDatePicker /*: Dynamical, Bondable */ {
     } else {
       let d = DatePickerDynamic<NSDate>(control: self)
       
-      let bond = Bond<NSDate>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.date = v
+      let bond = Bond<NSDate>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.date = $0
         }
       }
       

--- a/Bond/Bond+UIImageView.swift
+++ b/Bond/Bond+UIImageView.swift
@@ -35,7 +35,7 @@ extension UIImageView: Bondable {
       return (d as? Dynamic<UIImage?>)!
     } else {
       let d = InternalDynamic<UIImage?>(self.image)
-      let bond = Bond<UIImage?>() { [weak self] v in if let s = self { s.image = v } }
+      let bond = Bond<UIImage?>() { [weak self] in self?.image = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &imageDynamicHandleUIImageView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UILabel.swift
+++ b/Bond/Bond+UILabel.swift
@@ -36,7 +36,7 @@ extension UILabel: Bondable {
       return (d as? Dynamic<String>)!
     } else {
       let d = InternalDynamic<String>(self.text ?? "")
-      let bond = Bond<String>() { [weak self] v in if let s = self { s.text = v } }
+      let bond = Bond<String>() { [weak self] in self?.text = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &textDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -49,7 +49,7 @@ extension UILabel: Bondable {
       return (d as? Dynamic<NSAttributedString>)!
     } else {
       let d = InternalDynamic<NSAttributedString>(self.attributedText ?? NSAttributedString(string: ""))
-      let bond = Bond<NSAttributedString>() { [weak self] v in if let s = self { s.attributedText = v } }
+      let bond = Bond<NSAttributedString>() { [weak self] in self?.attributedText = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &attributedTextDynamicHandleUILabel, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UIProgressView.swift
+++ b/Bond/Bond+UIProgressView.swift
@@ -35,7 +35,7 @@ extension UIProgressView: Bondable {
       return (d as? Dynamic<Float>)!
     } else {
       let d = InternalDynamic<Float>(self.progress)
-      let bond = Bond<Float>() { [weak self] v in if let s = self { s.progress = v } }
+      let bond = Bond<Float>() { [weak self] in self?.progress = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &progressDynamicHandleUIProgressView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UISlider.swift
+++ b/Bond/Bond+UISlider.swift
@@ -71,9 +71,9 @@ extension UISlider /*: Dynamical, Bondable */ {
     } else {
       let d = SliderDynamic<Float>(control: self)
       
-      let bond = Bond<Float>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.value = v
+      let bond = Bond<Float>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.value = $0
         }
       }
       

--- a/Bond/Bond+UISwitch.swift
+++ b/Bond/Bond+UISwitch.swift
@@ -70,9 +70,9 @@ extension UISwitch /*: Dynamical, Bondable */ {
     } else {
       let d = SwitchDynamic<Bool>(control: self)
       
-      let bond = Bond<Bool>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.on = v
+      let bond = Bond<Bool>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.on = $0
         }
       }
       

--- a/Bond/Bond+UITextField.swift
+++ b/Bond/Bond+UITextField.swift
@@ -71,9 +71,9 @@ extension UITextField /*: Dynamical, Bondable */ {
       return (d as? Dynamic<String>)!
     } else {
       let d = TextFieldDynamic<String>(control: self)
-      let bond = Bond<String>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.text = v
+      let bond = Bond<String>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.text = $0
         }
       }
       d.bindTo(bond, fire: false, strongly: false)
@@ -88,7 +88,7 @@ extension UITextField /*: Dynamical, Bondable */ {
       return (d as? Dynamic<Bool>)!
     } else {
       let d = InternalDynamic<Bool>(self.enabled)
-      let bond = Bond<Bool>() { [weak self] v in if let s = self { s.enabled = v } }
+      let bond = Bond<Bool>() { [weak self] in self?.enabled = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &enabledDynamicHandleUITextField, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))

--- a/Bond/Bond+UITextView.swift
+++ b/Bond/Bond+UITextView.swift
@@ -45,9 +45,9 @@ extension UITextView: Bondable {
         }
       }
       
-      let bond = Bond<String>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.text = v
+      let bond = Bond<String>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.text = $0
         }
       }
       
@@ -71,9 +71,9 @@ extension UITextView: Bondable {
         }
       }
       
-      let bond = Bond<NSAttributedString>() { [weak self, weak d] v in
-        if let s = self, d = d where !d.updatingFromSelf {
-          s.attributedText = v
+      let bond = Bond<NSAttributedString>() { [weak self, weak d] in
+        if let d = d where !d.updatingFromSelf {
+          self?.attributedText = $0
         }
       }
       

--- a/Bond/Bond+UIView.swift
+++ b/Bond/Bond+UIView.swift
@@ -38,7 +38,7 @@ extension UIView {
       return (d as? Dynamic<UIColor>)!
     } else {
       let d = InternalDynamic<UIColor>(self.backgroundColor ?? UIColor.clearColor())
-      let bond = Bond<UIColor>() { [weak self] v in if let s = self { s.backgroundColor = v } }
+      let bond = Bond<UIColor>() { [weak self] in self?.backgroundColor = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &backgroundColorDynamicHandleUIView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -51,7 +51,7 @@ extension UIView {
       return (d as? Dynamic<CGFloat>)!
     } else {
       let d = InternalDynamic<CGFloat>(self.alpha)
-      let bond = Bond<CGFloat>() { [weak self] v in if let s = self { s.alpha = v } }
+      let bond = Bond<CGFloat>() { [weak self] in self?.alpha = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &alphaDynamicHandleUIView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))
@@ -64,7 +64,7 @@ extension UIView {
       return (d as? Dynamic<Bool>)!
     } else {
       let d = InternalDynamic<Bool>(self.hidden)
-      let bond = Bond<Bool>() { [weak self] v in if let s = self { s.hidden = v } }
+      let bond = Bond<Bool>() { [weak self] in self?.hidden = $0 }
       d.bindTo(bond, fire: false, strongly: false)
       d.retain(bond)
       objc_setAssociatedObject(self, &hiddenDynamicHandleUIView, d, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN_NONATOMIC))


### PR DESCRIPTION
This pull request is in response to issue #99 

This request attempts to clean up declarations of dynamic variables so as to remove unnecessary variable declarations and if let... statements. 

The scope of the changes made thus far in this pull request are limited to dynamic variables. While examining the project I noticed other classes where an instance of the variable 'self' was explicitly defined (in particular the UITableView and UICollectionView extensions). I did not modify these variables yet as I was not certain what style choices would be preferred. See my newest comment in issue #99  for details. 