### PR TITLE
Batch updates

### DIFF
--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		DCA979851A83C52D00DD4A30 /* Bond+Arrays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 69491BCB1A7C21B600A13B6B /* Bond+Arrays.swift */; };
 		DFC184961B34193A00B3444E /* PerformanceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = DFC184951B34193A00B3444E /* PerformanceTests.swift */; };
 		EA3E36B81B41702100559641 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
+		EA45874A1B41936600C1F4C3 /* UICollectionViewDataSourceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4587491B41936600C1F4C3 /* UICollectionViewDataSourceTests.swift */; };
 		EA4BFACD1B41722D00DFA736 /* UINavigationItemTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA4BFACC1B41722D00DFA736 /* UINavigationItemTests.swift */; };
 		EAD8B2DD1B41AF4300995CE9 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
 		EAD8B2FB1B41B04500995CE9 /* Bond+NSButton.swift in Sources */ = {isa = PBXBuildFile; fileRef = EAD8B2DF1B41B04500995CE9 /* Bond+NSButton.swift */; };
@@ -169,6 +170,7 @@
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		DFC184951B34193A00B3444E /* PerformanceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = PerformanceTests.swift; sourceTree = "<group>"; };
 		EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintTests.swift; sourceTree = "<group>"; };
+		EA4587491B41936600C1F4C3 /* UICollectionViewDataSourceTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UICollectionViewDataSourceTests.swift; sourceTree = "<group>"; };
 		EA4BFACC1B41722D00DFA736 /* UINavigationItemTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = UINavigationItemTests.swift; sourceTree = "<group>"; };
 		EAD8B2DF1B41B04500995CE9 /* Bond+NSButton.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+NSButton.swift"; sourceTree = "<group>"; };
 		EAD8B2E01B41B04500995CE9 /* Bond+NSColorWell.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = "Bond+NSColorWell.swift"; sourceTree = "<group>"; };
@@ -250,6 +252,7 @@
 			isa = PBXGroup;
 			children = (
 				CC581F751AE23D8B00D69AE7 /* UITableViewDataSourceTests.swift */,
+				EA4587491B41936600C1F4C3 /* UICollectionViewDataSourceTests.swift */,
 				03A5DC991AAF971F007616B4 /* UIViewTests.swift */,
 				03A5DC9F1AAF982D007616B4 /* UIImageViewTests.swift */,
 				03A5DC9D1AAF97E9007616B4 /* UIProgressViewTests.swift */,
@@ -699,6 +702,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				EA45874A1B41936600C1F4C3 /* UICollectionViewDataSourceTests.swift in Sources */,
 				03A5DCA01AAF982D007616B4 /* UIImageViewTests.swift in Sources */,
 				03A5DCA21AAF9893007616B4 /* UIBarItemTests.swift in Sources */,
 				EA4BFACD1B41722D00DFA736 /* UINavigationItemTests.swift in Sources */,

--- a/BondTests/ArrayTests.swift
+++ b/BondTests/ArrayTests.swift
@@ -496,6 +496,7 @@ class ArrayTests: XCTestCase {
     let e1 = expectationWithDescription("Insert")
     let e2 = expectationWithDescription("Remove")
     let e3 = expectationWithDescription("Update")
+    let e4 = expectationWithDescription("BatchUpdates")
     
     bond.didInsertListener = { a, i in
       XCTAssert(NSThread.isMainThread(), "Invalid queue")
@@ -511,7 +512,12 @@ class ArrayTests: XCTestCase {
       XCTAssert(NSThread.isMainThread(), "Invalid queue")
       e3.fulfill()
     }
-        
+    
+    bond.didPerformBatchUpdatesListener = {
+      XCTAssert(NSThread.isMainThread(), "Invalid queue")
+      e4.fulfill()
+    }
+    
     deliveredOn ->| bond
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
@@ -524,6 +530,12 @@ class ArrayTests: XCTestCase {
     
     dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
       array[0] = 2
+    }
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+      array.beginBatchUpdates()
+    }
+    dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) {
+      array.endBatchUpdates()
     }
     
     waitForExpectationsWithTimeout(1, handler: nil)

--- a/BondTests/UICollectionViewDataSourceTests.swift
+++ b/BondTests/UICollectionViewDataSourceTests.swift
@@ -1,0 +1,243 @@
+
+import UIKit
+import Bond
+import XCTest
+
+enum CollectionOperation {
+  case BeginUpdates
+  case EndUpdates
+  case InsertItems([NSIndexPath])
+  case DeleteItems([NSIndexPath])
+  case ReloadItems([NSIndexPath])
+  case InsertSections(NSIndexSet)
+  case DeleteSections(NSIndexSet)
+  case ReloadSections(NSIndexSet)
+  case ReloadData
+}
+
+func ==(op0: CollectionOperation, op1: CollectionOperation) -> Bool {
+  switch (op0, op1) {
+  case (.BeginUpdates, .BeginUpdates):
+    return true
+  case (.EndUpdates, .EndUpdates):
+    return true
+  case let (.InsertItems(paths0), .InsertItems(paths1)):
+    return paths0 == paths1
+  case let (.DeleteItems(paths0), .DeleteItems(paths1)):
+    return paths0 == paths1
+  case let (.ReloadItems(paths0), .ReloadItems(paths1)):
+    return paths0 == paths1
+  case let (.InsertSections(i0), .InsertSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case let (.DeleteSections(i0), .DeleteSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case let (.ReloadSections(i0), .ReloadSections(i1)):
+    return i0.isEqualToIndexSet(i1)
+  case (.ReloadData, .ReloadData):
+    return true
+  default:
+    return false
+  }
+}
+
+func wrapUpdate(ops: CollectionOperation...) -> [CollectionOperation] {
+  return [.BeginUpdates] + ops + [.EndUpdates]
+}
+
+extension CollectionOperation: Equatable, Printable {
+  var description: String {
+    switch self {
+    case .BeginUpdates:
+      return "BeginUpdates"
+    case .EndUpdates:
+      return "EndUpdates"
+    case let .InsertItems(indexPaths):
+      return "InsertItems(\(indexPaths)"
+    case let .DeleteItems(indexPaths):
+      return "DeleteItems(\(indexPaths)"
+    case let .ReloadItems(indexPaths):
+      return "ReloadItems(\(indexPaths)"
+    case let .InsertSections(indices):
+      return "InsertSections(\(indices)"
+    case let .DeleteSections(indices):
+      return "DeleteSections(\(indices)"
+    case let .ReloadSections(indices):
+      return "ReloadSections(\(indices)"
+    case .ReloadData:
+      return "ReloadData"
+    }
+  }
+}
+
+class TestCollectionView: UICollectionView {
+  var operations = [CollectionOperation]()
+  var onceBatchUpdatesCompleted: ((Bool) -> ())?
+  
+  override func performBatchUpdates(updates: (() -> Void)?, completion: ((Bool) -> Void)?) {
+    operations.append(.BeginUpdates)
+    super.performBatchUpdates(updates, completion: { (finished) -> Void in
+      self.operations.append(.EndUpdates)
+      completion?(finished)
+      self.onceBatchUpdatesCompleted?(finished)
+      self.onceBatchUpdatesCompleted = nil
+    })
+  }
+  
+  override func insertItemsAtIndexPaths(indexPaths: [AnyObject]) {
+    operations.append(.InsertItems(indexPaths as! [NSIndexPath]))
+    super.insertItemsAtIndexPaths(indexPaths)
+  }
+  
+  override func deleteItemsAtIndexPaths(indexPaths: [AnyObject]) {
+    operations.append(.DeleteItems(indexPaths as! [NSIndexPath]))
+    super.deleteItemsAtIndexPaths(indexPaths)
+  }
+  
+  override func reloadItemsAtIndexPaths(indexPaths: [AnyObject]) {
+    operations.append(.ReloadItems(indexPaths as! [NSIndexPath]))
+    super.reloadItemsAtIndexPaths(indexPaths)
+  }
+  
+  override func insertSections(sections: NSIndexSet) {
+    operations.append(.InsertSections(sections))
+    super.insertSections(sections)
+  }
+  
+  override func deleteSections(sections: NSIndexSet) {
+    operations.append(.DeleteSections(sections))
+    super.deleteSections(sections)
+  }
+  
+  override func reloadSections(sections: NSIndexSet) {
+    operations.append(.ReloadSections(sections))
+    super.reloadSections(sections)
+  }
+  
+  override func reloadData() {
+    operations.append(.ReloadData)
+    super.reloadData()
+  }
+}
+
+// TODO: Add test for mixed section & object updates
+
+class UICollectionViewDataSourceTests: XCTestCase {
+  var collectionView: TestCollectionView!
+  var array: DynamicArray<DynamicArray<Int>>!
+  var bond: UICollectionViewDataSourceBond<Void>!
+  var expectedOperations: [CollectionOperation]!
+  override func setUp() {
+    array = DynamicArray([DynamicArray([1, 2]), DynamicArray([3, 4])])
+    let collectionView = TestCollectionView(frame: CGRectZero, collectionViewLayout: UICollectionViewFlowLayout())
+    self.collectionView = collectionView
+    collectionView.registerClass(UICollectionViewCell.self, forCellWithReuseIdentifier: "cellID")
+    expectedOperations = []
+    bond = UICollectionViewDataSourceBond(collectionView: collectionView)
+    array.map { array, sectionIndex in
+      array.map { int, index -> UICollectionViewCell in
+        return collectionView.dequeueReusableCellWithReuseIdentifier("cellID", forIndexPath: NSIndexPath(forItem: index, inSection: sectionIndex)) as! UICollectionViewCell
+      }
+    } ->> bond
+    expectedOperations.append(.ReloadData) // `tableView` will get a `reloadData` when the bond is attached
+    
+    // NOTE: Force collectionView to actually load items in section so that later tests do not fail
+    // with NSInconsistency exception related to InvalidUpdate
+    // http://stackoverflow.com/questions/13392413/uicollectionview-insertitemsatindexpaths-throws-exception
+    XCTAssertEqual(collectionView.numberOfSections(), 2, "2 sections before set")
+    collectionView.numberOfItemsInSection(0)
+  }
+  
+  func testReload() {
+    collectionView.reloadData()
+    expectedOperations.append(.ReloadData)
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+
+    let e = expectationWithDescription("batchComplete")
+    collectionView.performBatchUpdates({
+        self.collectionView.reloadData()
+    }, completion: { finished in
+      XCTAssertEqual(self.expectedOperations, self.collectionView.operations, "operation sequence did not match")
+      e.fulfill()
+    })
+    
+    // NOTE: UICollectionView internally calls ReloadData once after batchUpdates if reloadData is called from within batchUpdates
+    expectedOperations.extend(wrapUpdate(.ReloadData, .ReloadData))
+    waitForExpectationsWithTimeout(1, handler: nil)
+  }
+  
+  func testReloadViaDynamicArray() {
+    array.setArray([])
+    // NOTE: UICollectionView internally calls ReloadData once after batchUpdates if reloadData is called from within batchUpdates
+    expectedOperations.extend([.ReloadData])
+    XCTAssertEqual(self.expectedOperations, self.collectionView.operations, "operation sequence did not match")
+  }
+
+  func testInsertAItem() {
+    array[1].append(5)
+    expectedOperations.extend([.BeginUpdates, .InsertItems([NSIndexPath(forItem: 2, inSection: 1)])])
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 3, "items count incorrect")
+  }
+
+  func testDeleteAItem() {
+    array[1].removeLast()
+    expectedOperations.extend([.BeginUpdates, .DeleteItems([NSIndexPath(forItem: 1, inSection: 1)])])
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 1, "items count incorrect")
+  }
+
+  func testReloadAItem() {
+    array[1][1] = 5
+    expectedOperations.extend([.BeginUpdates, .ReloadItems([NSIndexPath(forItem: 1, inSection: 1)])])
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+  }
+
+  func testInsertASection() {
+    array.insert(DynamicArray([7, 8, 9]), atIndex: 1)
+    expectedOperations.extend([.BeginUpdates, .InsertSections(NSIndexSet(index: 1))])
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 3, "wrong number of Items in new section")
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+  }
+
+  func testDeleteASection() {
+    array.removeAtIndex(0)
+    expectedOperations.extend([.BeginUpdates, .DeleteSections(NSIndexSet(index: 0))])
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+  }
+
+  func testReloadASection() {
+    array[1] = DynamicArray([5, 6, 7])
+    expectedOperations.extend([.BeginUpdates, .ReloadSections(NSIndexSet(index: 1))])
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 3, "wrong number of Items in reloaded section")
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+  }
+
+  func testBatchUpdates() {
+    array.beginBatchUpdates()
+    array[1] = DynamicArray([5, 6, 7, 8])
+    array[1].beginBatchUpdates()
+    array[1].insert(4, atIndex: 0)
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 2, "wrong number of Items in reloaded section")
+    
+    array[1].endBatchUpdates()
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 2, "wrong number of Items in reloaded section")
+    
+    array.endBatchUpdates()
+    expectedOperations.extend([
+      .BeginUpdates,
+      .ReloadSections(NSIndexSet(index: 1)),
+      .InsertItems([NSIndexPath(forItem: 0, inSection: 1)])
+    ])
+    XCTAssertEqual(collectionView.numberOfItemsInSection(1), 5, "wrong number of Items in reloaded section")
+    XCTAssertEqual(expectedOperations, collectionView.operations, "operation sequence did not match")
+    
+    let e = expectationWithDescription("End Updates")
+    expectedOperations.extend([.EndUpdates])
+    collectionView.onceBatchUpdatesCompleted = { _ in
+        XCTAssertEqual(self.expectedOperations, self.collectionView.operations, "operation sequence did not match")
+      e.fulfill()
+    }
+    waitForExpectationsWithTimeout(1, handler: nil)
+  }
+}


### PR DESCRIPTION
This set of changes is likely to be much more controversial. However the motivation is that in order to be performant at scale the ability to batch changes and animate together instead of animating each change one at a time is gonna be pretty critical. I particular I expect the `beginBatchUpdates` and `endBatchUpdates` functions to be called from Core Data `NSFetchedResultsController`. I did add a lot more test and verity that it works in a real application and followed the implementation pattern, but I also understand the difficulty of adding to API surface. 