### PR TITLE
Fixed didResetListener in UICollectionViewDataSourceBond

### DIFF
--- a/Bond/iOS/Bond+UICollectionView.swift
+++ b/Bond/iOS/Bond+UICollectionView.swift
@@ -158,8 +158,14 @@ public class UICollectionViewDataSourceBond<T>: ArrayBond<DynamicArray<UICollect
     }
     
     self.didResetListener = { [weak self] array in
-      if let collectionView = self?.collectionView {
-        collectionView.reloadData()
+      if let s = self, let collectionView = s.collectionView {
+        for section in 0..<array.count {
+          let sectionBond = UICollectionViewDataSourceSectionBond<Void>(collectionView: collectionView, section: section, shouldReloadItems: s.shouldReloadItems)
+          let sectionDynamic = array[section]
+          sectionDynamic.bindTo(sectionBond)
+          s.sectionBonds.append(sectionBond)
+          collectionView.reloadData()
+        }
       }
     }
   }


### PR DESCRIPTION
Calling ```setArray()``` of data source didn't cause update of ```sectionBonds``` property in ```UICollectionViewDataSourceBond```. This issue causes _Array index out of range_ error if call ```setArray(...)``` on data source and then call ```append(...)```.