### PR TITLE
fix nextDataSource issue

### DIFF
--- a/Bond/iOS/Bond+UITableView.swift
+++ b/Bond/iOS/Bond+UITableView.swift
@@ -177,7 +177,7 @@ public class UITableViewDataSourceBond<T>: ArrayBond<DynamicArray<UITableViewCel
   private var sectionBonds: [UITableViewDataSourceSectionBond<Void>] = []
   public let disableAnimation: Bool
   public weak var nextDataSource: UITableViewDataSource? {
-    didSet(newValue) {
+    willSet(newValue) {
       dataSource?.nextDataSource = newValue
     }
   }

--- a/BondTests/UITableViewDataSourceTests.swift
+++ b/BondTests/UITableViewDataSourceTests.swift
@@ -93,6 +93,21 @@ class TestTableView: UITableView {
   }
 }
 
+class TestNextDataSource:NSObject, UITableViewDataSource {
+  func tableView(tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
+    return 1
+  }
+  
+  func tableView(tableView: UITableView, cellForRowAtIndexPath indexPath: NSIndexPath) -> UITableViewCell {
+    return UITableViewCell()
+  }
+  
+  func tableView(tableView: UITableView, canEditRowAtIndexPath indexPath: NSIndexPath) -> Bool {
+    return true
+  }
+}
+
+
 class UITableViewDataSourceTests: XCTestCase {
   var tableView: TestTableView!
   var array: DynamicArray<DynamicArray<Int>>!
@@ -155,5 +170,12 @@ class UITableViewDataSourceTests: XCTestCase {
     expectedOperations.append(.ReloadSections(NSIndexSet(index: 1)))
     XCTAssertEqual(tableView.numberOfRowsInSection(1), 3, "wrong number of rows in reloaded section")
     XCTAssertEqual(expectedOperations, tableView.operations, "operation sequence did not match")
+  }
+  
+  func testNextDataSource() {
+    let nextDataSource = TestNextDataSource()
+    bond.nextDataSource = nextDataSource
+    XCTAssertEqual(tableView.numberOfRowsInSection(1), 2, "wrong number of rows in section 1, nextDataSource should not override numberOfRowsInSection")
+    XCTAssertEqual(tableView.dataSource!.tableView!(tableView, canEditRowAtIndexPath: NSIndexPath(forRow: 0, inSection: 0)), true, "nextDataSource should override canEdiRowAtIndexPath")
   }
 }


### PR DESCRIPTION
With this PR, we use "willSet" instead of "didSet". In [apple document](https://developer.apple.com/library/prerelease/ios/documentation/Swift/Conceptual/Swift_Programming_Language/Declarations.html) said, "In contrast to the willSet observer, the old value of the variable or property is passed to the didSet observer in case you still need access to it".
We can only set nil to the nextDataSource of dataSource if we use didSet.
I also add test case to verify the result.
This is my first pull request on github. If I miss anything please let me know.
Thank you.