### PR TITLE
add dispatch queue to map function

### DIFF
--- a/Bond/Bond.swift
+++ b/Bond/Bond.swift
@@ -229,6 +229,10 @@ public extension Dynamic
   public func map<U>(f: T -> U) -> Dynamic<U> {
     return _map(self, f)
   }
+
+  public func map<U>(queue: dispatch_queue_t, f: T -> U) -> Dynamic<U> {
+    return _map(self, f, queue)
+  }
   
   public func filter(f: T -> Bool) -> Dynamic<T> {
     return _filter(self, f)

--- a/BondTests/FunctionalTests.swift
+++ b/BondTests/FunctionalTests.swift
@@ -22,6 +22,21 @@ class ReduceTests: XCTestCase {
     d1.value = 2
     XCTAssert(m.value == "2", "Value after dynamic change")
   }
+
+  func testMap2() {
+    let d1 = Dynamic<Int>(0)
+    let m = d1.map(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0)) { "\($0)" }
+
+    dispatch_async(dispatch_get_main_queue()) {
+      XCTAssert(m.value == "0", "Initial value")
+      XCTAssert(m.valid == true, "Should not be faulty")
+    }
+
+    d1.value = 2
+    dispatch_async(dispatch_get_main_queue()) {
+      XCTAssert(m.value == "2", "Value after dynamic change")
+    }
+  }
   
   func testFilter() {
     let d1 = Dynamic<Int>(0)


### PR DESCRIPTION
### Problem

For example, I wanna bind `image_url` to `dynImage` with `map` function, for each cell on UITableView.
But the codes for getting UIImage (`map's closure`) is running in `MainThread`.
So when I scroll the table view, the scroll animation seems to be so unsteady!!

```
map(some.image_url) { urlString in
  var url = NSURL(string: urlString)
  if let existUrl = url {
    var data = NSData(contentsOfURL: existUrl)
    if let existData = data {
      return UIImage(data: existData)!
    }
  }
  return UIImage()
} ->> cell.avatarImageView.dynImage
```

so I made a PR. But I think this is not the best solution. Could you give me any idea if you can?