### PR TITLE
Changes for Xcode7 Beta 6

### DIFF
--- a/Bond/Core/ObservableArray.swift
+++ b/Bond/Core/ObservableArray.swift
@@ -112,7 +112,7 @@ public final class ObservableArray<ElementType>: Observable<ObservableArrayEvent
     case .Reset(let newArray):
       array = newArray
     case .Insert(let elements, let fromIndex):
-      array.splice(elements, atIndex: fromIndex)
+      array.insertContentsOf(elements, at: fromIndex)
     case .Update(let elements, let fromIndex):
       for (index, element) in elements.enumerate() {
         array[fromIndex + index] = element
@@ -254,10 +254,10 @@ public extension ObservableType where EventType: ObservableArrayEventType {
   
   /// Map overload that simplifies mapping of observables that generate ObservableArray events.
   /// Instead of mapping ObservableArray events, it maps the array elements from those events.
-  public func map<T>(transform: ElementType -> T) -> Observable<ObservableArrayEvent<LazySequence<MapSequence<Self.EventType.ObservableArrayEventSequenceType, T>>>> {
+  public func map<T>(transform: ElementType -> T) -> Observable<ObservableArrayEvent<LazyMapSequence<Self.EventType.ObservableArrayEventSequenceType, T>>> {
     return Observable(replayLength: replayLength) { sink in
       return observe { arrayEvent in
-        let sequence = lazy(arrayEvent.sequence).map(transform)
+        let sequence = arrayEvent.sequence.lazy.map(transform)
         let operation = arrayEvent.operation.map(transform)
         sink(ObservableArrayEvent(sequence: sequence, operation: operation))
       }
@@ -265,7 +265,7 @@ public extension ObservableType where EventType: ObservableArrayEventType {
   }
   
   /// Filter overload that filters array elements instead of its events.
-  public func filter(includeElement: ElementType -> Bool) -> Observable<ObservableArrayEvent<LazySequence<FilterSequence<Self.EventType.ObservableArrayEventSequenceType>>>> {
+  public func filter(includeElement: ElementType -> Bool) -> Observable<ObservableArrayEvent<LazyFilterSequence<Self.EventType.ObservableArrayEventSequenceType>>> {
     
     var pointers: [Int]? = nil
     
@@ -276,7 +276,7 @@ public extension ObservableType where EventType: ObservableArrayEventType {
           pointers = pointersFromSequence(arrayEvent.sequence, includeElement: includeElement)
         }
         
-        let sequence = lazy(arrayEvent.sequence).filter(includeElement)
+        let sequence = arrayEvent.sequence.lazy.filter(includeElement)
         if let operation = arrayEvent.operation.filter(includeElement, pointers: &pointers!) {
           sink(ObservableArrayEvent(sequence: sequence, operation: operation))
         }
@@ -309,10 +309,10 @@ public extension ObservableType where EventType: ObservableArrayEventType, Event
   
   /// Map overload that simplifies mapping of observables that generate ObservableArray events.
   /// Instead of mapping ObservableArray events, it maps the array elements from those events.
-  public func map<T>(transform: _ElementType -> T) -> Observable<ObservableArrayEvent<LazyForwardCollection<MapCollection<Self.EventType.ObservableArrayEventSequenceType, T>>>> {
+  public func map<T>(transform: _ElementType -> T) -> Observable<ObservableArrayEvent<LazyMapCollection<Self.EventType.ObservableArrayEventSequenceType, T>>> {
     return Observable(replayLength: replayLength) { sink in
       return observe { arrayEvent in
-        let sequence = lazy(arrayEvent.sequence).map(transform)
+        let sequence = arrayEvent.sequence.lazy.map(transform)
         let operation = arrayEvent.operation.map(transform)
         sink(ObservableArrayEvent(sequence: sequence, operation: operation))
       }

--- a/Bond/Core/ObservableArrayEvent.swift
+++ b/Bond/Core/ObservableArrayEvent.swift
@@ -110,7 +110,7 @@ public extension ObservableArrayOperation {
       
       if insertedIndices.count > 0 {
         let insertionPoint = startingIndexForIndex(fromIndex, forPointers: pointers)
-        pointers.splice(insertedIndices, atIndex: insertionPoint)
+        pointers.insertContentsOf(insertedIndices, at: insertionPoint)
         return .Insert(elements: insertedElements, fromIndex: insertionPoint)
       }
       

--- a/Bond/Core/OptionalType.swift
+++ b/Bond/Core/OptionalType.swift
@@ -30,13 +30,13 @@ public protocol OptionalType {
 }
 
 extension Optional: OptionalType {
-  public typealias SomeType = T
+  public typealias SomeType = Wrapped
   
   public var isNil: Bool {
     return self == nil
   }
   
-  public var value: T? {
+  public var value: Wrapped? {
     return self
   }
   


### PR DESCRIPTION
@srdanrasic I was in need of a version of Bond-4 that compiles and runs on Xcode 7 Beta 6.

I'm not fully up on the Swift generics yet, so I'm not sure if I did the right thing with the ObservableArray map.

Tests all run on iOS.