### PR TITLE
Resolve error when compiling with Xcode 7.0 GM.

### DIFF
--- a/Bond/Bond+Arrays.swift
+++ b/Bond/Bond+Arrays.swift
@@ -148,7 +148,7 @@ public class DynamicArray<T>: Dynamic<Array<T>>, SequenceType {
     if array.count > 0 {
       let indices = Array(i..<i+array.count)
       dispatchWillInsert(indices)
-      value.splice(array, atIndex: i)
+      value.insertContentsOf(array, at: i)
       dispatchDidInsert(indices)
     }
   }


### PR DESCRIPTION
Correct syntax in Bond+Arrays to fix an error when compiling with Xcode 7.0 GM