### PR TITLE
Fix improper use of objc_setAssociatedObject.

### DIFF
--- a/Bond/Extensions/OSX/NSTableView+Bond.swift
+++ b/Bond/Extensions/OSX/NSTableView+Bond.swift
@@ -128,11 +128,11 @@ public extension EventProducerType where EventType: ObservableArrayEventType {
     }
 
     let dataSource = BNDTableViewDataSource<DelegateType>(array: array, tableView: tableView, delegate: delegate)
-    objc_setAssociatedObject(tableView, NSTableView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    objc_setAssociatedObject(tableView, &NSTableView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
 
     return BlockDisposable { [weak tableView] in
       if let tableView = tableView {
-        objc_setAssociatedObject(tableView, NSTableView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(tableView, &NSTableView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
       }
     }
   }

--- a/Bond/Extensions/iOS/UICollectionView+Bond.swift
+++ b/Bond/Extensions/iOS/UICollectionView+Bond.swift
@@ -171,11 +171,11 @@ public extension EventProducerType where
     
     let dataSource = BNDCollectionViewDataSource(array: array, collectionView: collectionView, proxyDataSource: proxyDataSource, createCell: createCell)
     collectionView.dataSource = dataSource
-    objc_setAssociatedObject(collectionView, UICollectionView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    objc_setAssociatedObject(collectionView, &UICollectionView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     
     return BlockDisposable { [weak collectionView] in
       if let collectionView = collectionView {
-        objc_setAssociatedObject(collectionView, UICollectionView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(collectionView, &UICollectionView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
       }
     }
   }

--- a/Bond/Extensions/iOS/UITableView+Bond.swift
+++ b/Bond/Extensions/iOS/UITableView+Bond.swift
@@ -195,11 +195,11 @@ public extension EventProducerType where
     }
     
     let dataSource = BNDTableViewDataSource(array: array, tableView: tableView, proxyDataSource: proxyDataSource, createCell: createCell)
-    objc_setAssociatedObject(tableView, UITableView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+    objc_setAssociatedObject(tableView, &UITableView.AssociatedKeys.BondDataSourceKey, dataSource, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
     
     return BlockDisposable { [weak tableView] in
       if let tableView = tableView {
-        objc_setAssociatedObject(tableView, UITableView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
+        objc_setAssociatedObject(tableView, &UITableView.AssociatedKeys.BondDataSourceKey, nil, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN_NONATOMIC)
       }
     }
   }


### PR DESCRIPTION
It's easy to reproduce the problem by pasting the following code into Playground:

```
import Foundation

var key = "TheKey"
let parentObj = NSString(string: "Parent")
func printChild() {
  let val: AnyObject! = objc_getAssociatedObject(parentObj, key)
  print("\(parentObj) - \(val)")
}

printChild()

func doStuff() {
  let child = NSString(string: "Child")
  objc_setAssociatedObject(parentObj, key, child, objc_AssociationPolicy.OBJC_ASSOCIATION_RETAIN)
  printChild()
}

doStuff()
printChild()
```