### PR TITLE
Update Bond.podspec to 4.0.0

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "4.0.0-beta3"
+  s.version      = "4.0.0"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC


### PR DESCRIPTION
The Cocoapod version in the `.podspec` file does not match what the `README.md` was giving for installation instructions.

This fixes that, and now Bond is *actually* retrievable via:
`pod 'Bond', '~> 4.0'`