### PR TITLE
Standardizing on 'observer' for 'target'

### DIFF
--- a/README.md
+++ b/README.md
@@ -306,7 +306,7 @@ captainName.observe { name in
 }
 ```
 
-That well make the label text update whenever the captain changes. 
+That will make the label text update whenever the captain changes. 
 
 ```swift
 captainName.next(“Janeway”)

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ Bindings are at the core of Bond and there ought to be even simpler way to estab
 captainName.bindTo(nameLabelText)
 ```
 
-Event producers and obsevables can be bound to any object that conforms to `BindableType` protocol. Event producers themselves conform to that protocol, but you can make any type conform to it.
+Event producers and observables can be bound to any object that conforms to `BindableType` protocol. Event producers themselves conform to that protocol, but you can make any type conform to it.
 
 Method `bindTo` returns a disposable that can cancel the binding. You usually don't need to worry about that because binding will be automatically canceled when either the event producer or observer are deallocated.
 

--- a/README.md
+++ b/README.md
@@ -321,7 +321,7 @@ captainName.bindTo(nameLabelText)
 
 Event producers and obsevables can be bound to any object that conforms to `BindableType` protocol. Event producers themselves conform to that protocol, but you can make any type conform to it.
 
-Method `bindTo` returns a disposable that can cancel the binding. You usually don't need to worry about that because binding will be automatically canceled when either the event producer or target are deallocated.
+Method `bindTo` returns a disposable that can cancel the binding. You usually don't need to worry about that because binding will be automatically canceled when either the event producer or observer are deallocated.
 
 ### UIKit and AppKit
 
@@ -361,7 +361,7 @@ class MyViewController: UIViewController {
 }
 ``` 
 
-Note that it's not necessary to dispose bindings. When the binding target is deallocated, the binding will be automatically disposed. That means that the following code is valid even if the view model outlives the view controller:
+Note that it's not necessary to dispose bindings. When the observer is deallocated, the binding will be automatically disposed. That means that the following code is valid even if the view model outlives the view controller:
 
 ```swift
 class MyViewController: UIViewController {


### PR DESCRIPTION
While reading the documentation, I found a few uses of the word 'target'. These confused me, because 'target' was not a standard descriptor throughout the documentation, so I was not immediately sure what it was referring to.

This replaces all (2) usages of 'target' for 'observer', which is the word used throughout the rest of the documentation to describe such a thing.

Also, fixed some small typos. :)
