### PR TITLE
tvOS support

### DIFF
--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "4.0.0-beta3"
+  s.version      = "4.0.0"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/srdanrasic"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v4.0.0-beta3" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v4.0.0" }
   s.source_files  = ["Bond", "Bond/Core", "Bond/Extensions/Shared", "Bond/Extensions/OSX", "Bond/Extensions/iOS"]
   s.ios.exclude_files = "Bond/Extensions/OSX"
   s.osx.exclude_files = "Bond/Extensions/iOS"

--- a/Bond.podspec
+++ b/Bond.podspec
@@ -1,7 +1,7 @@
 Pod::Spec.new do |s|
 
   s.name         = "Bond"
-  s.version      = "4.0.0"
+  s.version      = "4.0.1"
   s.summary      = "A Swift binding framework"
 
   s.description  = <<-DESC
@@ -18,7 +18,7 @@ Pod::Spec.new do |s|
   s.social_media_url   = "http://twitter.com/srdanrasic"
   s.ios.deployment_target = "8.0"
   s.osx.deployment_target = "10.10"
-  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v4.0.0" }
+  s.source       = { :git => "https://github.com/SwiftBond/Bond.git", :tag => "v4.0.1" }
   s.source_files  = ["Bond", "Bond/Core", "Bond/Extensions/Shared", "Bond/Extensions/OSX", "Bond/Extensions/iOS"]
   s.ios.exclude_files = "Bond/Extensions/OSX"
   s.osx.exclude_files = "Bond/Extensions/iOS"

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -13,14 +13,14 @@
 		03ACB50A1AB555D6001B3E64 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB5091AB555D6001B3E64 /* Images.xcassets */; };
 		03ACB50D1AB555D6001B3E64 /* LaunchScreen.xib in Resources */ = {isa = PBXBuildFile; fileRef = 03ACB50B1AB555D6001B3E64 /* LaunchScreen.xib */; };
 		03ACB5231AB6C840001B3E64 /* AssertEqualForOptionals.swift in Sources */ = {isa = PBXBuildFile; fileRef = 03ACB5221AB6C840001B3E64 /* AssertEqualForOptionals.swift */; };
-		52CC7A1E1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1D1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		52CC7A201BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1F1BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift */; settings = {ASSET_TAGS = (); }; };
+		52CC7A1E1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1D1BC4C71F0010D41E /* NSAppearanceCustomization+Bond.swift */; };
+		52CC7A201BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 52CC7A1F1BC4C7DC0010D41E /* NSAppearanceCustomizationTests.swift */; };
 		69491BB41A7C217100A13B6B /* Bond.h in Headers */ = {isa = PBXBuildFile; fileRef = 69491BB31A7C217100A13B6B /* Bond.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		69491BBA1A7C217100A13B6B /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
 		790FD79C1B7F1C3800136394 /* NSTableView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FD79B1B7F1C3800136394 /* NSTableView+Bond.swift */; };
 		790FD79E1B7F1CF500136394 /* NSTableViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 790FD79D1B7F1CF500136394 /* NSTableViewTests.swift */; };
-		795D4C191B8F05C9001B80B0 /* NSIndexSet+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D4C181B8F05C9001B80B0 /* NSIndexSet+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		795D4C1A1B8F05C9001B80B0 /* NSIndexSet+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D4C181B8F05C9001B80B0 /* NSIndexSet+Bond.swift */; settings = {ASSET_TAGS = (); }; };
+		795D4C191B8F05C9001B80B0 /* NSIndexSet+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D4C181B8F05C9001B80B0 /* NSIndexSet+Bond.swift */; };
+		795D4C1A1B8F05C9001B80B0 /* NSIndexSet+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D4C181B8F05C9001B80B0 /* NSIndexSet+Bond.swift */; };
 		900BFC081ADFC5DC002B4B6E /* CALayerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC061ADFC5D5002B4B6E /* CALayerTests.swift */; };
 		900BFC0B1ADFC863002B4B6E /* NSButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC091ADFC860002B4B6E /* NSButtonTests.swift */; };
 		900BFC0E1ADFC9E9002B4B6E /* NSColorWellTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC0C1ADFC9A5002B4B6E /* NSColorWellTests.swift */; };
@@ -30,38 +30,41 @@
 		900BFC161ADFCC00002B4B6E /* NSStatusBarButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC151ADFCC00002B4B6E /* NSStatusBarButtonTests.swift */; };
 		900BFC181ADFCCEE002B4B6E /* NSTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC171ADFCCEE002B4B6E /* NSTextFieldTests.swift */; };
 		900BFC1A1ADFCD63002B4B6E /* NSTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC191ADFCD63002B4B6E /* NSTextViewTests.swift */; };
+		B54FBF0F1BC6997F00173E74 /* BondtvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B54FBF0E1BC6997F00173E74 /* BondtvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		B54FBF161BC6997F00173E74 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B54FBF0C1BC6997F00173E74 /* Bond.framework */; };
+		B54FBF1B1BC6997F00173E74 /* BondtvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */; };
 		DCA979741A83C3A200DD4A30 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA979691A83C3A100DD4A30 /* Bond.framework */; };
 		EA3E36B81B41702100559641 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
 		EAD8B2DD1B41AF4300995CE9 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
-		EC0075B31B90D39500249C31 /* EventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0075B21B90D39500249C31 /* EventProducer.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075B41B90D39500249C31 /* EventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0075B21B90D39500249C31 /* EventProducer.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075B51B90D73800249C31 /* NSLock+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E71B77BB1D00837A36 /* NSLock+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075B71B90DC2100249C31 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BF1B77BB1D00837A36 /* Observable.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075B91B90E4DC00249C31 /* NSObject+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E91B77BB1D00837A36 /* NSObject+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075BA1B90E55400249C31 /* NSNotificationCenter+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E81B77BB1D00837A36 /* NSNotificationCenter+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075BB1B90E56D00249C31 /* NSLayoutConstraint+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E61B77BB1D00837A36 /* NSLayoutConstraint+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075BC1B90E57300249C31 /* CALayer+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E51B77BB1D00837A36 /* CALayer+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075CF1B90E5F400249C31 /* UIActivityIndicatorView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CB1B77BB1D00837A36 /* UIActivityIndicatorView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D01B90E5F400249C31 /* UIRefreshControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2AE4A81B788F8B00296781 /* UIRefreshControl+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D11B90E5F400249C31 /* UIBarItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CC1B77BB1D00837A36 /* UIBarItem+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D21B90E5F400249C31 /* UIButton+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CD1B77BB1D00837A36 /* UIButton+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D31B90E5F400249C31 /* UICollectionView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CE1B77BB1D00837A36 /* UICollectionView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D41B90E5F400249C31 /* UIControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CF1B77BB1D00837A36 /* UIControl+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D51B90E5F400249C31 /* UIDatePicker+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D01B77BB1D00837A36 /* UIDatePicker+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D61B90E5F400249C31 /* UIImageView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D11B77BB1D00837A36 /* UIImageView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D71B90E5F400249C31 /* UILabel+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D21B77BB1D00837A36 /* UILabel+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D81B90E5F400249C31 /* UINavigationItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D31B77BB1D00837A36 /* UINavigationItem+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075D91B90E5F400249C31 /* UIProgressView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D41B77BB1D00837A36 /* UIProgressView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DA1B90E5F400249C31 /* UISlider+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D51B77BB1D00837A36 /* UISlider+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DB1B90E5F400249C31 /* UISwitch+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D61B77BB1D00837A36 /* UISwitch+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DC1B90E5F400249C31 /* UITableView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D71B77BB1D00837A36 /* UITableView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DD1B90E5F400249C31 /* UITextField+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D81B77BB1D00837A36 /* UITextField+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DE1B90E5F400249C31 /* UITextView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D91B77BB1D00837A36 /* UITextView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075DF1B90E5F400249C31 /* UIView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68DA1B77BB1D00837A36 /* UIView+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC0075E01B90E6C800249C31 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BF1B77BB1D00837A36 /* Observable.swift */; settings = {ASSET_TAGS = (); }; };
+		EC0075B31B90D39500249C31 /* EventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0075B21B90D39500249C31 /* EventProducer.swift */; };
+		EC0075B41B90D39500249C31 /* EventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0075B21B90D39500249C31 /* EventProducer.swift */; };
+		EC0075B51B90D73800249C31 /* NSLock+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E71B77BB1D00837A36 /* NSLock+Bond.swift */; };
+		EC0075B71B90DC2100249C31 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BF1B77BB1D00837A36 /* Observable.swift */; };
+		EC0075B91B90E4DC00249C31 /* NSObject+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E91B77BB1D00837A36 /* NSObject+Bond.swift */; };
+		EC0075BA1B90E55400249C31 /* NSNotificationCenter+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E81B77BB1D00837A36 /* NSNotificationCenter+Bond.swift */; };
+		EC0075BB1B90E56D00249C31 /* NSLayoutConstraint+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E61B77BB1D00837A36 /* NSLayoutConstraint+Bond.swift */; };
+		EC0075BC1B90E57300249C31 /* CALayer+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E51B77BB1D00837A36 /* CALayer+Bond.swift */; };
+		EC0075CF1B90E5F400249C31 /* UIActivityIndicatorView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CB1B77BB1D00837A36 /* UIActivityIndicatorView+Bond.swift */; };
+		EC0075D01B90E5F400249C31 /* UIRefreshControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC2AE4A81B788F8B00296781 /* UIRefreshControl+Bond.swift */; };
+		EC0075D11B90E5F400249C31 /* UIBarItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CC1B77BB1D00837A36 /* UIBarItem+Bond.swift */; };
+		EC0075D21B90E5F400249C31 /* UIButton+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CD1B77BB1D00837A36 /* UIButton+Bond.swift */; };
+		EC0075D31B90E5F400249C31 /* UICollectionView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CE1B77BB1D00837A36 /* UICollectionView+Bond.swift */; };
+		EC0075D41B90E5F400249C31 /* UIControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CF1B77BB1D00837A36 /* UIControl+Bond.swift */; };
+		EC0075D51B90E5F400249C31 /* UIDatePicker+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D01B77BB1D00837A36 /* UIDatePicker+Bond.swift */; };
+		EC0075D61B90E5F400249C31 /* UIImageView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D11B77BB1D00837A36 /* UIImageView+Bond.swift */; };
+		EC0075D71B90E5F400249C31 /* UILabel+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D21B77BB1D00837A36 /* UILabel+Bond.swift */; };
+		EC0075D81B90E5F400249C31 /* UINavigationItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D31B77BB1D00837A36 /* UINavigationItem+Bond.swift */; };
+		EC0075D91B90E5F400249C31 /* UIProgressView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D41B77BB1D00837A36 /* UIProgressView+Bond.swift */; };
+		EC0075DA1B90E5F400249C31 /* UISlider+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D51B77BB1D00837A36 /* UISlider+Bond.swift */; };
+		EC0075DB1B90E5F400249C31 /* UISwitch+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D61B77BB1D00837A36 /* UISwitch+Bond.swift */; };
+		EC0075DC1B90E5F400249C31 /* UITableView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D71B77BB1D00837A36 /* UITableView+Bond.swift */; };
+		EC0075DD1B90E5F400249C31 /* UITextField+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D81B77BB1D00837A36 /* UITextField+Bond.swift */; };
+		EC0075DE1B90E5F400249C31 /* UITextView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D91B77BB1D00837A36 /* UITextView+Bond.swift */; };
+		EC0075DF1B90E5F400249C31 /* UIView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68DA1B77BB1D00837A36 /* UIView+Bond.swift */; };
+		EC0075E01B90E6C800249C31 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BF1B77BB1D00837A36 /* Observable.swift */; };
 		EC0388991B0DD25700E32454 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 69491BAE1A7C217100A13B6B /* Bond.framework */; };
-		EC3228AA1B9F5673002BE73A /* UISegmentedControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3228A91B9F5673002BE73A /* UISegmentedControl+Bond.swift */; settings = {ASSET_TAGS = (); }; };
-		EC3228AC1B9F5691002BE73A /* UISegmentedControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3228AB1B9F5691002BE73A /* UISegmentedControlTests.swift */; settings = {ASSET_TAGS = (); }; };
+		EC3228AA1B9F5673002BE73A /* UISegmentedControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3228A91B9F5673002BE73A /* UISegmentedControl+Bond.swift */; };
+		EC3228AC1B9F5691002BE73A /* UISegmentedControlTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3228AB1B9F5691002BE73A /* UISegmentedControlTests.swift */; };
 		EC6F105B1B7F9C2700E55A5F /* ObservableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD69821B77D45600837A36 /* ObservableTests.swift */; };
 		ECAD68EB1B77BB1D00837A36 /* BindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68B81B77BB1D00837A36 /* BindableType.swift */; };
 		ECAD68EC1B77BB1D00837A36 /* BindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68B81B77BB1D00837A36 /* BindableType.swift */; };
@@ -122,7 +125,7 @@
 		ECBF04DF1B808B20001F6BCA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBF04DE1B808B20001F6BCA /* DisposableTests.swift */; };
 		ECBF04E01B808B20001F6BCA /* DisposableTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECBF04DE1B808B20001F6BCA /* DisposableTests.swift */; };
 		ECBF04E11B810100001F6BCA /* NSLock+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E71B77BB1D00837A36 /* NSLock+Bond.swift */; };
-		ECF53FE61B8CDEA200628FCD /* ObservableArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD69841B77D45600837A36 /* ObservableArrayTests.swift */; settings = {ASSET_TAGS = (); }; };
+		ECF53FE61B8CDEA200628FCD /* ObservableArrayTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD69841B77D45600837A36 /* ObservableArrayTests.swift */; };
 		ECFFF4BB1B84B840001B5B0D /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFFF4BA1B84B840001B5B0D /* NSObjectTests.swift */; };
 		ECFFF4BC1B84B840001B5B0D /* NSObjectTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECFFF4BA1B84B840001B5B0D /* NSObjectTests.swift */; };
 /* End PBXBuildFile section */
@@ -141,6 +144,13 @@
 			proxyType = 1;
 			remoteGlobalIDString = 69491BAD1A7C217100A13B6B;
 			remoteInfo = Bond;
+		};
+		B54FBF171BC6997F00173E74 /* PBXContainerItemProxy */ = {
+			isa = PBXContainerItemProxy;
+			containerPortal = 69491BA51A7C217100A13B6B /* Project object */;
+			proxyType = 1;
+			remoteGlobalIDString = B54FBF0B1BC6997F00173E74;
+			remoteInfo = BondtvOS;
 		};
 		DCA979751A83C3A200DD4A30 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -188,6 +198,12 @@
 		900BFC151ADFCC00002B4B6E /* NSStatusBarButtonTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSStatusBarButtonTests.swift; sourceTree = "<group>"; };
 		900BFC171ADFCCEE002B4B6E /* NSTextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextFieldTests.swift; sourceTree = "<group>"; };
 		900BFC191ADFCD63002B4B6E /* NSTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextViewTests.swift; sourceTree = "<group>"; };
+		B54FBF0C1BC6997F00173E74 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		B54FBF0E1BC6997F00173E74 /* BondtvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BondtvOS.h; sourceTree = "<group>"; };
+		B54FBF101BC6997F00173E74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondtvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BondtvOSTests.swift; sourceTree = "<group>"; };
+		B54FBF1C1BC6997F00173E74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DCA979691A83C3A100DD4A30 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintTests.swift; sourceTree = "<group>"; };
@@ -287,6 +303,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B54FBF081BC6997F00173E74 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B54FBF121BC6997F00173E74 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B54FBF161BC6997F00173E74 /* Bond.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCA979651A83C3A100DD4A30 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -352,6 +383,8 @@
 				69491BBD1A7C217100A13B6B /* BondTests */,
 				03ACB4FF1AB555D6001B3E64 /* iOSAppForTesting */,
 				03ACB5151AB555D6001B3E64 /* iOSAppForTestingTests */,
+				B54FBF0D1BC6997F00173E74 /* BondtvOS */,
+				B54FBF191BC6997F00173E74 /* BondtvOSTests */,
 				69491BAF1A7C217100A13B6B /* Products */,
 			);
 			indentWidth = 2;
@@ -367,6 +400,8 @@
 				DCA979691A83C3A100DD4A30 /* Bond.framework */,
 				DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */,
 				03ACB4FE1AB555D6001B3E64 /* iOSAppForTesting.app */,
+				B54FBF0C1BC6997F00173E74 /* Bond.framework */,
+				B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -436,6 +471,24 @@
 				900BFC061ADFC5D5002B4B6E /* CALayerTests.swift */,
 			);
 			name = Shared;
+			sourceTree = "<group>";
+		};
+		B54FBF0D1BC6997F00173E74 /* BondtvOS */ = {
+			isa = PBXGroup;
+			children = (
+				B54FBF0E1BC6997F00173E74 /* BondtvOS.h */,
+				B54FBF101BC6997F00173E74 /* Info.plist */,
+			);
+			path = BondtvOS;
+			sourceTree = "<group>";
+		};
+		B54FBF191BC6997F00173E74 /* BondtvOSTests */ = {
+			isa = PBXGroup;
+			children = (
+				B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */,
+				B54FBF1C1BC6997F00173E74 /* Info.plist */,
+			);
+			path = BondtvOSTests;
 			sourceTree = "<group>";
 		};
 		ECAD68B71B77BB1D00837A36 /* Core */ = {
@@ -571,6 +624,14 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B54FBF091BC6997F00173E74 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B54FBF0F1BC6997F00173E74 /* BondtvOS.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCA979661A83C3A100DD4A30 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -636,6 +697,42 @@
 			productReference = 69491BB91A7C217100A13B6B /* BondTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B54FBF0B1BC6997F00173E74 /* BondtvOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B54FBF211BC6997F00173E74 /* Build configuration list for PBXNativeTarget "BondtvOS" */;
+			buildPhases = (
+				B54FBF071BC6997F00173E74 /* Sources */,
+				B54FBF081BC6997F00173E74 /* Frameworks */,
+				B54FBF091BC6997F00173E74 /* Headers */,
+				B54FBF0A1BC6997F00173E74 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = BondtvOS;
+			productName = BondtvOS;
+			productReference = B54FBF0C1BC6997F00173E74 /* Bond.framework */;
+			productType = "com.apple.product-type.framework";
+		};
+		B54FBF141BC6997F00173E74 /* BondtvOSTests */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B54FBF221BC6997F00173E74 /* Build configuration list for PBXNativeTarget "BondtvOSTests" */;
+			buildPhases = (
+				B54FBF111BC6997F00173E74 /* Sources */,
+				B54FBF121BC6997F00173E74 /* Frameworks */,
+				B54FBF131BC6997F00173E74 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+				B54FBF181BC6997F00173E74 /* PBXTargetDependency */,
+			);
+			name = BondtvOSTests;
+			productName = BondtvOSTests;
+			productReference = B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */;
+			productType = "com.apple.product-type.bundle.unit-test";
+		};
 		DCA979681A83C3A100DD4A30 /* BondOSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DCA9797C1A83C3A200DD4A30 /* Build configuration list for PBXNativeTarget "BondOSX" */;
@@ -692,6 +789,12 @@
 						CreatedOnToolsVersion = 6.1.1;
 						TestTargetID = 03ACB4FD1AB555D6001B3E64;
 					};
+					B54FBF0B1BC6997F00173E74 = {
+						CreatedOnToolsVersion = 7.1;
+					};
+					B54FBF141BC6997F00173E74 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					DCA979681A83C3A100DD4A30 = {
 						CreatedOnToolsVersion = 6.2;
 					};
@@ -718,6 +821,8 @@
 				DCA979681A83C3A100DD4A30 /* BondOSX */,
 				DCA979721A83C3A200DD4A30 /* BondOSXTests */,
 				03ACB4FD1AB555D6001B3E64 /* iOSAppForTesting */,
+				B54FBF0B1BC6997F00173E74 /* BondtvOS */,
+				B54FBF141BC6997F00173E74 /* BondtvOSTests */,
 			);
 		};
 /* End PBXProject section */
@@ -741,6 +846,20 @@
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 		69491BB71A7C217100A13B6B /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B54FBF0A1BC6997F00173E74 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B54FBF131BC6997F00173E74 /* Resources */ = {
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
@@ -851,6 +970,21 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B54FBF071BC6997F00173E74 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B54FBF111BC6997F00173E74 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B54FBF1B1BC6997F00173E74 /* BondtvOSTests.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCA979641A83C3A100DD4A30 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -922,6 +1056,11 @@
 			isa = PBXTargetDependency;
 			target = 69491BAD1A7C217100A13B6B /* Bond */;
 			targetProxy = 69491BBB1A7C217100A13B6B /* PBXContainerItemProxy */;
+		};
+		B54FBF181BC6997F00173E74 /* PBXTargetDependency */ = {
+			isa = PBXTargetDependency;
+			target = B54FBF0B1BC6997F00173E74 /* BondtvOS */;
+			targetProxy = B54FBF171BC6997F00173E74 /* PBXContainerItemProxy */;
 		};
 		DCA979761A83C3A200DD4A30 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1135,6 +1274,80 @@
 			};
 			name = Release;
 		};
+		B54FBF1D1BC6997F00173E74 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BondtvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOS;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		B54FBF1E1BC6997F00173E74 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				APPLICATION_EXTENSION_API_ONLY = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				DEFINES_MODULE = YES;
+				DYLIB_COMPATIBILITY_VERSION = 1;
+				DYLIB_CURRENT_VERSION = 1;
+				DYLIB_INSTALL_NAME_BASE = "@rpath";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BondtvOS/Info.plist;
+				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOS;
+				PRODUCT_NAME = "$(PROJECT_NAME)";
+				SDKROOT = appletvos;
+				SKIP_INSTALL = YES;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
+		B54FBF1F1BC6997F00173E74 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BondtvOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		B54FBF201BC6997F00173E74 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = BondtvOSTests/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOSTests;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 		DCA9797D1A83C3A200DD4A30 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1255,6 +1468,22 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		B54FBF211BC6997F00173E74 /* Build configuration list for PBXNativeTarget "BondtvOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B54FBF1D1BC6997F00173E74 /* Debug */,
+				B54FBF1E1BC6997F00173E74 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+		};
+		B54FBF221BC6997F00173E74 /* Build configuration list for PBXNativeTarget "BondtvOSTests" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B54FBF1F1BC6997F00173E74 /* Debug */,
+				B54FBF201BC6997F00173E74 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		DCA9797C1A83C3A200DD4A30 /* Build configuration list for PBXNativeTarget "BondOSX" */ = {
 			isa = XCConfigurationList;

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -30,9 +30,40 @@
 		900BFC161ADFCC00002B4B6E /* NSStatusBarButtonTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC151ADFCC00002B4B6E /* NSStatusBarButtonTests.swift */; };
 		900BFC181ADFCCEE002B4B6E /* NSTextFieldTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC171ADFCCEE002B4B6E /* NSTextFieldTests.swift */; };
 		900BFC1A1ADFCD63002B4B6E /* NSTextViewTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 900BFC191ADFCD63002B4B6E /* NSTextViewTests.swift */; };
-		B54FBF0F1BC6997F00173E74 /* BondtvOS.h in Headers */ = {isa = PBXBuildFile; fileRef = B54FBF0E1BC6997F00173E74 /* BondtvOS.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		B54FBF161BC6997F00173E74 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = B54FBF0C1BC6997F00173E74 /* Bond.framework */; };
-		B54FBF1B1BC6997F00173E74 /* BondtvOSTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */; };
+		B57E36881BD87A9200EE2212 /* EventProducerType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C01B77BB1D00837A36 /* EventProducerType.swift */; };
+		B57E36891BD87A9200EE2212 /* EventProducer.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC0075B21B90D39500249C31 /* EventProducer.swift */; };
+		B57E368A1BD87A9200EE2212 /* Observable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BF1B77BB1D00837A36 /* Observable.swift */; };
+		B57E368B1BD87A9200EE2212 /* ObservableArray.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C71B77BB1D00837A36 /* ObservableArray.swift */; };
+		B57E368C1BD87A9200EE2212 /* ObservableArrayEvent.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C81B77BB1D00837A36 /* ObservableArrayEvent.swift */; };
+		B57E368D1BD87A9200EE2212 /* DisposableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BC1B77BB1D00837A36 /* DisposableType.swift */; };
+		B57E368E1BD87A9200EE2212 /* Disposable.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68BB1B77BB1D00837A36 /* Disposable.swift */; };
+		B57E368F1BD87A9200EE2212 /* BindableType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68B81B77BB1D00837A36 /* BindableType.swift */; };
+		B57E36901BD87A9200EE2212 /* OptionalType.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C21B77BB1D00837A36 /* OptionalType.swift */; };
+		B57E36911BD87A9200EE2212 /* Buffer.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68B91B77BB1D00837A36 /* Buffer.swift */; };
+		B57E36921BD87A9200EE2212 /* Queue.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C41B77BB1D00837A36 /* Queue.swift */; };
+		B57E36931BD87A9200EE2212 /* Reference.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C51B77BB1D00837A36 /* Reference.swift */; };
+		B57E36941BD87A9200EE2212 /* Operators.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68C11B77BB1D00837A36 /* Operators.swift */; };
+		B57E36951BD87AA800EE2212 /* UIActivityIndicatorView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CB1B77BB1D00837A36 /* UIActivityIndicatorView+Bond.swift */; };
+		B57E36961BD87AA800EE2212 /* UISegmentedControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC3228A91B9F5673002BE73A /* UISegmentedControl+Bond.swift */; };
+		B57E36981BD87AA800EE2212 /* UIBarItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CC1B77BB1D00837A36 /* UIBarItem+Bond.swift */; };
+		B57E36991BD87AA800EE2212 /* UIButton+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CD1B77BB1D00837A36 /* UIButton+Bond.swift */; };
+		B57E369A1BD87AA800EE2212 /* UICollectionView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CE1B77BB1D00837A36 /* UICollectionView+Bond.swift */; };
+		B57E369B1BD87AA800EE2212 /* UIControl+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68CF1B77BB1D00837A36 /* UIControl+Bond.swift */; };
+		B57E369D1BD87AA800EE2212 /* UIImageView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D11B77BB1D00837A36 /* UIImageView+Bond.swift */; };
+		B57E369E1BD87AA800EE2212 /* UILabel+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D21B77BB1D00837A36 /* UILabel+Bond.swift */; };
+		B57E369F1BD87AA800EE2212 /* UINavigationItem+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D31B77BB1D00837A36 /* UINavigationItem+Bond.swift */; };
+		B57E36A01BD87AA800EE2212 /* UIProgressView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D41B77BB1D00837A36 /* UIProgressView+Bond.swift */; };
+		B57E36A31BD87AA800EE2212 /* UITableView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D71B77BB1D00837A36 /* UITableView+Bond.swift */; };
+		B57E36A41BD87AA800EE2212 /* UITextField+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D81B77BB1D00837A36 /* UITextField+Bond.swift */; };
+		B57E36A51BD87AA800EE2212 /* UITextView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68D91B77BB1D00837A36 /* UITextView+Bond.swift */; };
+		B57E36A61BD87AA800EE2212 /* UIView+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68DA1B77BB1D00837A36 /* UIView+Bond.swift */; };
+		B5B474CA1BD87BBE004BD69C /* CALayer+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E51B77BB1D00837A36 /* CALayer+Bond.swift */; };
+		B5B474CB1BD87BBE004BD69C /* NSIndexSet+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = 795D4C181B8F05C9001B80B0 /* NSIndexSet+Bond.swift */; };
+		B5B474CC1BD87BBE004BD69C /* NSLayoutConstraint+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E61B77BB1D00837A36 /* NSLayoutConstraint+Bond.swift */; };
+		B5B474CD1BD87BBE004BD69C /* NSLock+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E71B77BB1D00837A36 /* NSLock+Bond.swift */; };
+		B5B474CE1BD87BBE004BD69C /* NSNotificationCenter+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E81B77BB1D00837A36 /* NSNotificationCenter+Bond.swift */; };
+		B5B474CF1BD87BBE004BD69C /* NSObject+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E91B77BB1D00837A36 /* NSObject+Bond.swift */; };
 		DCA979741A83C3A200DD4A30 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA979691A83C3A100DD4A30 /* Bond.framework */; };
 		EA3E36B81B41702100559641 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
 		EAD8B2DD1B41AF4300995CE9 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
@@ -199,11 +230,7 @@
 		900BFC171ADFCCEE002B4B6E /* NSTextFieldTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextFieldTests.swift; sourceTree = "<group>"; };
 		900BFC191ADFCD63002B4B6E /* NSTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextViewTests.swift; sourceTree = "<group>"; };
 		B54FBF0C1BC6997F00173E74 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
-		B54FBF0E1BC6997F00173E74 /* BondtvOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = BondtvOS.h; sourceTree = "<group>"; };
-		B54FBF101BC6997F00173E74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondtvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
-		B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BondtvOSTests.swift; sourceTree = "<group>"; };
-		B54FBF1C1BC6997F00173E74 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DCA979691A83C3A100DD4A30 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintTests.swift; sourceTree = "<group>"; };
@@ -383,8 +410,6 @@
 				69491BBD1A7C217100A13B6B /* BondTests */,
 				03ACB4FF1AB555D6001B3E64 /* iOSAppForTesting */,
 				03ACB5151AB555D6001B3E64 /* iOSAppForTestingTests */,
-				B54FBF0D1BC6997F00173E74 /* BondtvOS */,
-				B54FBF191BC6997F00173E74 /* BondtvOSTests */,
 				69491BAF1A7C217100A13B6B /* Products */,
 			);
 			indentWidth = 2;
@@ -471,24 +496,6 @@
 				900BFC061ADFC5D5002B4B6E /* CALayerTests.swift */,
 			);
 			name = Shared;
-			sourceTree = "<group>";
-		};
-		B54FBF0D1BC6997F00173E74 /* BondtvOS */ = {
-			isa = PBXGroup;
-			children = (
-				B54FBF0E1BC6997F00173E74 /* BondtvOS.h */,
-				B54FBF101BC6997F00173E74 /* Info.plist */,
-			);
-			path = BondtvOS;
-			sourceTree = "<group>";
-		};
-		B54FBF191BC6997F00173E74 /* BondtvOSTests */ = {
-			isa = PBXGroup;
-			children = (
-				B54FBF1A1BC6997F00173E74 /* BondtvOSTests.swift */,
-				B54FBF1C1BC6997F00173E74 /* Info.plist */,
-			);
-			path = BondtvOSTests;
 			sourceTree = "<group>";
 		};
 		ECAD68B71B77BB1D00837A36 /* Core */ = {
@@ -628,7 +635,6 @@
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B54FBF0F1BC6997F00173E74 /* BondtvOS.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -974,6 +980,39 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				B5B474CA1BD87BBE004BD69C /* CALayer+Bond.swift in Sources */,
+				B5B474CB1BD87BBE004BD69C /* NSIndexSet+Bond.swift in Sources */,
+				B5B474CC1BD87BBE004BD69C /* NSLayoutConstraint+Bond.swift in Sources */,
+				B5B474CD1BD87BBE004BD69C /* NSLock+Bond.swift in Sources */,
+				B5B474CE1BD87BBE004BD69C /* NSNotificationCenter+Bond.swift in Sources */,
+				B5B474CF1BD87BBE004BD69C /* NSObject+Bond.swift in Sources */,
+				B57E36951BD87AA800EE2212 /* UIActivityIndicatorView+Bond.swift in Sources */,
+				B57E36961BD87AA800EE2212 /* UISegmentedControl+Bond.swift in Sources */,
+				B57E36981BD87AA800EE2212 /* UIBarItem+Bond.swift in Sources */,
+				B57E36991BD87AA800EE2212 /* UIButton+Bond.swift in Sources */,
+				B57E369A1BD87AA800EE2212 /* UICollectionView+Bond.swift in Sources */,
+				B57E369B1BD87AA800EE2212 /* UIControl+Bond.swift in Sources */,
+				B57E369D1BD87AA800EE2212 /* UIImageView+Bond.swift in Sources */,
+				B57E369E1BD87AA800EE2212 /* UILabel+Bond.swift in Sources */,
+				B57E369F1BD87AA800EE2212 /* UINavigationItem+Bond.swift in Sources */,
+				B57E36A01BD87AA800EE2212 /* UIProgressView+Bond.swift in Sources */,
+				B57E36A31BD87AA800EE2212 /* UITableView+Bond.swift in Sources */,
+				B57E36A41BD87AA800EE2212 /* UITextField+Bond.swift in Sources */,
+				B57E36A51BD87AA800EE2212 /* UITextView+Bond.swift in Sources */,
+				B57E36A61BD87AA800EE2212 /* UIView+Bond.swift in Sources */,
+				B57E36881BD87A9200EE2212 /* EventProducerType.swift in Sources */,
+				B57E36891BD87A9200EE2212 /* EventProducer.swift in Sources */,
+				B57E368A1BD87A9200EE2212 /* Observable.swift in Sources */,
+				B57E368B1BD87A9200EE2212 /* ObservableArray.swift in Sources */,
+				B57E368C1BD87A9200EE2212 /* ObservableArrayEvent.swift in Sources */,
+				B57E368D1BD87A9200EE2212 /* DisposableType.swift in Sources */,
+				B57E368E1BD87A9200EE2212 /* Disposable.swift in Sources */,
+				B57E368F1BD87A9200EE2212 /* BindableType.swift in Sources */,
+				B57E36901BD87A9200EE2212 /* OptionalType.swift in Sources */,
+				B57E36911BD87A9200EE2212 /* Buffer.swift in Sources */,
+				B57E36921BD87A9200EE2212 /* Queue.swift in Sources */,
+				B57E36931BD87A9200EE2212 /* Reference.swift in Sources */,
+				B57E36941BD87A9200EE2212 /* Operators.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -981,7 +1020,6 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				B54FBF1B1BC6997F00173E74 /* BondtvOSTests.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1277,14 +1315,14 @@
 		B54FBF1D1BC6997F00173E74 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = BondtvOS/Info.plist;
+				INFOPLIST_FILE = Bond/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOS;
@@ -1299,7 +1337,7 @@
 		B54FBF1E1BC6997F00173E74 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
-				APPLICATION_EXTENSION_API_ONLY = YES;
+				APPLICATION_EXTENSION_API_ONLY = NO;
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEFINES_MODULE = YES;
@@ -1307,7 +1345,7 @@
 				DYLIB_CURRENT_VERSION = 1;
 				DYLIB_INSTALL_NAME_BASE = "@rpath";
 				GCC_NO_COMMON_BLOCKS = YES;
-				INFOPLIST_FILE = BondtvOS/Info.plist;
+				INFOPLIST_FILE = Bond/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = swift.bond.Bond.BondtvOS;
@@ -1476,6 +1514,7 @@
 				B54FBF1E1BC6997F00173E74 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		B54FBF221BC6997F00173E74 /* Build configuration list for PBXNativeTarget "BondtvOSTests" */ = {
 			isa = XCConfigurationList;
@@ -1484,6 +1523,7 @@
 				B54FBF201BC6997F00173E74 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		DCA9797C1A83C3A200DD4A30 /* Build configuration list for PBXNativeTarget "BondOSX" */ = {
 			isa = XCConfigurationList;

--- a/Bond.xcodeproj/project.pbxproj
+++ b/Bond.xcodeproj/project.pbxproj
@@ -64,6 +64,10 @@
 		B5B474CD1BD87BBE004BD69C /* NSLock+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E71B77BB1D00837A36 /* NSLock+Bond.swift */; };
 		B5B474CE1BD87BBE004BD69C /* NSNotificationCenter+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E81B77BB1D00837A36 /* NSNotificationCenter+Bond.swift */; };
 		B5B474CF1BD87BBE004BD69C /* NSObject+Bond.swift in Sources */ = {isa = PBXBuildFile; fileRef = ECAD68E91B77BB1D00837A36 /* NSObject+Bond.swift */; };
+		B5E724A91BD88E8600704E16 /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E724A81BD88E8600704E16 /* AppDelegate.swift */; };
+		B5E724AB1BD88E8600704E16 /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = B5E724AA1BD88E8600704E16 /* ViewController.swift */; };
+		B5E724AE1BD88E8600704E16 /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = B5E724AC1BD88E8600704E16 /* Main.storyboard */; };
+		B5E724B01BD88E8600704E16 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = B5E724AF1BD88E8600704E16 /* Assets.xcassets */; };
 		DCA979741A83C3A200DD4A30 /* Bond.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = DCA979691A83C3A100DD4A30 /* Bond.framework */; };
 		EA3E36B81B41702100559641 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
 		EAD8B2DD1B41AF4300995CE9 /* NSLayoutConstraintTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */; };
@@ -231,6 +235,12 @@
 		900BFC191ADFCD63002B4B6E /* NSTextViewTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSTextViewTests.swift; sourceTree = "<group>"; };
 		B54FBF0C1BC6997F00173E74 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondtvOSTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5E724A61BD88E8600704E16 /* tvOSAppForTesting.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = tvOSAppForTesting.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		B5E724A81BD88E8600704E16 /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		B5E724AA1BD88E8600704E16 /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		B5E724AD1BD88E8600704E16 /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		B5E724AF1BD88E8600704E16 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		B5E724B11BD88E8600704E16 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		DCA979691A83C3A100DD4A30 /* Bond.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bond.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		DCA979731A83C3A200DD4A30 /* BondOSXTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = BondOSXTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		EA3E36B71B41702100559641 /* NSLayoutConstraintTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NSLayoutConstraintTests.swift; sourceTree = "<group>"; };
@@ -345,6 +355,13 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B5E724A31BD88E8600704E16 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCA979651A83C3A100DD4A30 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -410,6 +427,7 @@
 				69491BBD1A7C217100A13B6B /* BondTests */,
 				03ACB4FF1AB555D6001B3E64 /* iOSAppForTesting */,
 				03ACB5151AB555D6001B3E64 /* iOSAppForTestingTests */,
+				B5E724A71BD88E8600704E16 /* tvOSAppForTesting */,
 				69491BAF1A7C217100A13B6B /* Products */,
 			);
 			indentWidth = 2;
@@ -427,6 +445,7 @@
 				03ACB4FE1AB555D6001B3E64 /* iOSAppForTesting.app */,
 				B54FBF0C1BC6997F00173E74 /* Bond.framework */,
 				B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */,
+				B5E724A61BD88E8600704E16 /* tvOSAppForTesting.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -496,6 +515,18 @@
 				900BFC061ADFC5D5002B4B6E /* CALayerTests.swift */,
 			);
 			name = Shared;
+			sourceTree = "<group>";
+		};
+		B5E724A71BD88E8600704E16 /* tvOSAppForTesting */ = {
+			isa = PBXGroup;
+			children = (
+				B5E724A81BD88E8600704E16 /* AppDelegate.swift */,
+				B5E724AA1BD88E8600704E16 /* ViewController.swift */,
+				B5E724AC1BD88E8600704E16 /* Main.storyboard */,
+				B5E724AF1BD88E8600704E16 /* Assets.xcassets */,
+				B5E724B11BD88E8600704E16 /* Info.plist */,
+			);
+			path = tvOSAppForTesting;
 			sourceTree = "<group>";
 		};
 		ECAD68B71B77BB1D00837A36 /* Core */ = {
@@ -739,6 +770,23 @@
 			productReference = B54FBF151BC6997F00173E74 /* BondtvOSTests.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
+		B5E724A51BD88E8600704E16 /* tvOSAppForTesting */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = B5E724B21BD88E8600704E16 /* Build configuration list for PBXNativeTarget "tvOSAppForTesting" */;
+			buildPhases = (
+				B5E724A21BD88E8600704E16 /* Sources */,
+				B5E724A31BD88E8600704E16 /* Frameworks */,
+				B5E724A41BD88E8600704E16 /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = tvOSAppForTesting;
+			productName = tvOSAppForTesting;
+			productReference = B5E724A61BD88E8600704E16 /* tvOSAppForTesting.app */;
+			productType = "com.apple.product-type.application";
+		};
 		DCA979681A83C3A100DD4A30 /* BondOSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = DCA9797C1A83C3A200DD4A30 /* Build configuration list for PBXNativeTarget "BondOSX" */;
@@ -801,6 +849,9 @@
 					B54FBF141BC6997F00173E74 = {
 						CreatedOnToolsVersion = 7.1;
 					};
+					B5E724A51BD88E8600704E16 = {
+						CreatedOnToolsVersion = 7.1;
+					};
 					DCA979681A83C3A100DD4A30 = {
 						CreatedOnToolsVersion = 6.2;
 					};
@@ -829,6 +880,7 @@
 				03ACB4FD1AB555D6001B3E64 /* iOSAppForTesting */,
 				B54FBF0B1BC6997F00173E74 /* BondtvOS */,
 				B54FBF141BC6997F00173E74 /* BondtvOSTests */,
+				B5E724A51BD88E8600704E16 /* tvOSAppForTesting */,
 			);
 		};
 /* End PBXProject section */
@@ -869,6 +921,15 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		B5E724A41BD88E8600704E16 /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5E724B01BD88E8600704E16 /* Assets.xcassets in Resources */,
+				B5E724AE1BD88E8600704E16 /* Main.storyboard in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1023,6 +1084,15 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		B5E724A21BD88E8600704E16 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				B5E724AB1BD88E8600704E16 /* ViewController.swift in Sources */,
+				B5E724A91BD88E8600704E16 /* AppDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		DCA979641A83C3A100DD4A30 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -1127,6 +1197,14 @@
 				03ACB50C1AB555D6001B3E64 /* Base */,
 			);
 			name = LaunchScreen.xib;
+			sourceTree = "<group>";
+		};
+		B5E724AC1BD88E8600704E16 /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				B5E724AD1BD88E8600704E16 /* Base */,
+			);
+			name = Main.storyboard;
 			sourceTree = "<group>";
 		};
 /* End PBXVariantGroup section */
@@ -1386,6 +1464,41 @@
 			};
 			name = Release;
 		};
+		B5E724B31BD88E8600704E16 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = tvOSAppForTesting/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bond.tvOSAppForTesting;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Debug;
+		};
+		B5E724B41BD88E8600704E16 /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = "App Icon & Top Shelf Image";
+				ASSETCATALOG_COMPILER_LAUNCHIMAGE_NAME = LaunchImage;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				GCC_NO_COMMON_BLOCKS = YES;
+				INFOPLIST_FILE = tvOSAppForTesting/Info.plist;
+				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = com.bond.tvOSAppForTesting;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SDKROOT = appletvos;
+				TARGETED_DEVICE_FAMILY = 3;
+				TVOS_DEPLOYMENT_TARGET = 9.0;
+			};
+			name = Release;
+		};
 		DCA9797D1A83C3A200DD4A30 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1524,6 +1637,14 @@
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
+		};
+		B5E724B21BD88E8600704E16 /* Build configuration list for PBXNativeTarget "tvOSAppForTesting" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				B5E724B31BD88E8600704E16 /* Debug */,
+				B5E724B41BD88E8600704E16 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
 		};
 		DCA9797C1A83C3A200DD4A30 /* Build configuration list for PBXNativeTarget "BondOSX" */ = {
 			isa = XCConfigurationList;

--- a/Bond.xcodeproj/xcshareddata/xcschemes/BondtvOS.xcscheme
+++ b/Bond.xcodeproj/xcshareddata/xcschemes/BondtvOS.xcscheme
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
+               BuildableName = "BondtvOS.framework"
+               BlueprintName = "BondtvOS"
+               ReferencedContainer = "container:Bond.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "B54FBF141BC6997F00173E74"
+               BuildableName = "BondtvOSTests.xctest"
+               BlueprintName = "BondtvOSTests"
+               ReferencedContainer = "container:Bond.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
+            BuildableName = "BondtvOS.framework"
+            BlueprintName = "BondtvOS"
+            ReferencedContainer = "container:Bond.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
+            BuildableName = "BondtvOS.framework"
+            BlueprintName = "BondtvOS"
+            ReferencedContainer = "container:Bond.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
+            BuildableName = "BondtvOS.framework"
+            BlueprintName = "BondtvOS"
+            ReferencedContainer = "container:Bond.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Bond.xcodeproj/xcshareddata/xcschemes/BondtvOS.xcscheme
+++ b/Bond.xcodeproj/xcshareddata/xcschemes/BondtvOS.xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
-               BuildableName = "BondtvOS.framework"
+               BuildableName = "Bond.framework"
                BlueprintName = "BondtvOS"
                ReferencedContainer = "container:Bond.xcodeproj">
             </BuildableReference>
@@ -43,7 +43,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
-            BuildableName = "BondtvOS.framework"
+            BuildableName = "Bond.framework"
             BlueprintName = "BondtvOS"
             ReferencedContainer = "container:Bond.xcodeproj">
          </BuildableReference>
@@ -65,7 +65,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
-            BuildableName = "BondtvOS.framework"
+            BuildableName = "Bond.framework"
             BlueprintName = "BondtvOS"
             ReferencedContainer = "container:Bond.xcodeproj">
          </BuildableReference>
@@ -83,7 +83,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "B54FBF0B1BC6997F00173E74"
-            BuildableName = "BondtvOS.framework"
+            BuildableName = "Bond.framework"
             BlueprintName = "BondtvOS"
             ReferencedContainer = "container:Bond.xcodeproj">
          </BuildableReference>

--- a/Bond/Core/ObservableArray.swift
+++ b/Bond/Core/ObservableArray.swift
@@ -230,18 +230,15 @@ public struct ObservableArrayGenerator<ElementType>: GeneratorType {
   }
 }
 
-public extension ObservableArray {
-  
-  /// Wraps the receiver into another array. This basically creates a array of arrays
-  /// with with a single element - the receiver array.
-  public func lift() -> ObservableArray<ObservableArray<ElementType>> {
-    return ObservableArray<ObservableArray<ElementType>>([self])
-  }
-}
-
 public extension EventProducerType where EventType: ObservableArrayEventType {
   
   private typealias ElementType = EventType.ObservableArrayEventSequenceType.Generator.Element
+  
+  /// Wraps the receiver into another array. This basically creates a array of arrays
+  /// with with a single element - the receiver array.
+  public func lift() -> ObservableArray<Self> {
+    return ObservableArray([self])
+  }
   
   /// Map overload that simplifies mapping of observables that generate ObservableArray events.
   /// Instead of mapping ObservableArray events, it maps the array elements from those events.

--- a/Bond/Extensions/Shared/NSLayoutConstraint+Bond.swift
+++ b/Bond/Extensions/Shared/NSLayoutConstraint+Bond.swift
@@ -22,7 +22,7 @@
 //  THE SOFTWARE.
 //
 
-#if os(iOS)
+#if os(iOS) || os(tvOS)
   import UIKit
 #else
   import AppKit

--- a/Bond/Extensions/Shared/NSObject+Bond.swift
+++ b/Bond/Extensions/Shared/NSObject+Bond.swift
@@ -133,7 +133,7 @@ public extension Observable where Wrapped: OptionalType {
     
     observeNew { value in
       if !updatingFromSelf {
-        observer.set(value as? AnyObject)
+        observer.set(value.value as? AnyObject)
       }
     }
   }

--- a/Bond/Info.plist
+++ b/Bond/Info.plist
@@ -15,7 +15,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>4.0.0</string>
+	<string>4.0.1</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>

--- a/iOSAppForTesting/Base.lproj/Main.storyboard
+++ b/iOSAppForTesting/Base.lproj/Main.storyboard
@@ -1,13 +1,14 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="6211" systemVersion="14A298i" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="9052" systemVersion="14F27" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" initialViewController="BYZ-38-t0r">
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="6204"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9040"/>
     </dependencies>
     <scenes>
         <!--View Controller-->
         <scene sceneID="tne-QT-ifu">
             <objects>
-                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="iOSAppForTesting" customModuleProvider="target" sceneMemberID="viewController">
                     <layoutGuides>
                         <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
                         <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>

--- a/tvOSAppForTesting/AppDelegate.swift
+++ b/tvOSAppForTesting/AppDelegate.swift
@@ -1,0 +1,46 @@
+//
+//  AppDelegate.swift
+//  tvOSAppForTesting
+//
+//  Created by Matthew Buckley on 10/21/15.
+//  Copyright © 2015 Bond. All rights reserved.
+//
+
+import UIKit
+
+@UIApplicationMain
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+    var window: UIWindow?
+
+
+    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    func applicationWillResignActive(application: UIApplication) {
+        // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
+        // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
+    }
+
+    func applicationDidEnterBackground(application: UIApplication) {
+        // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
+        // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
+    }
+
+    func applicationWillEnterForeground(application: UIApplication) {
+        // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
+    }
+
+    func applicationDidBecomeActive(application: UIApplication) {
+        // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
+    }
+
+    func applicationWillTerminate(application: UIApplication) {
+        // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
+    }
+
+
+}
+

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Large.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Back.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Contents.json
@@ -1,0 +1,17 @@
+{
+  "layers" : [
+    {
+      "filename" : "Front.imagestacklayer"
+    },
+    {
+      "filename" : "Middle.imagestacklayer"
+    },
+    {
+      "filename" : "Back.imagestacklayer"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Front.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Content.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/App Icon - Small.imagestack/Middle.imagestacklayer/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Contents.json
@@ -1,0 +1,26 @@
+{
+  "assets" : [
+    {
+      "size" : "1280x768",
+      "idiom" : "tv",
+      "filename" : "App Icon - Large.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "400x240",
+      "idiom" : "tv",
+      "filename" : "App Icon - Small.imagestack",
+      "role" : "primary-app-icon"
+    },
+    {
+      "size" : "1920x720",
+      "idiom" : "tv",
+      "filename" : "Top Shelf Image.imageset",
+      "role" : "top-shelf-image"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/App Icon & Top Shelf Image.brandassets/Top Shelf Image.imageset/Contents.json
@@ -1,0 +1,12 @@
+{
+  "images" : [
+    {
+      "idiom" : "tv",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Assets.xcassets/LaunchImage.launchimage/Contents.json
+++ b/tvOSAppForTesting/Assets.xcassets/LaunchImage.launchimage/Contents.json
@@ -1,0 +1,15 @@
+{
+  "images" : [
+    {
+      "orientation" : "landscape",
+      "idiom" : "tv",
+      "extent" : "full-screen",
+      "minimum-system-version" : "9.0",
+      "scale" : "1x"
+    }
+  ],
+  "info" : {
+    "version" : 1,
+    "author" : "xcode"
+  }
+}

--- a/tvOSAppForTesting/Base.lproj/Main.storyboard
+++ b/tvOSAppForTesting/Base.lproj/Main.storyboard
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder.AppleTV.Storyboard" version="3.0" toolsVersion="9052" systemVersion="14F27" targetRuntime="AppleTV" propertyAccessControl="none" useAutolayout="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="9040"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModule="tvOSAppForTesting" customModuleProvider="target" sceneMemberID="viewController">
+                    <layoutGuides>
+                        <viewControllerLayoutGuide type="top" id="y3c-jy-aDJ"/>
+                        <viewControllerLayoutGuide type="bottom" id="wfy-db-euE"/>
+                    </layoutGuides>
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="1920" height="1080"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <subviews>
+                            <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Background color is bound" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="agd-bx-eW3">
+                                <rect key="frame" x="268.5" y="469" width="1384" height="143.5"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="120"/>
+                                <color key="textColor" red="0.0" green="0.0" blue="0.0" alpha="1" colorSpace="calibratedRGB"/>
+                                <nil key="highlightedColor"/>
+                            </label>
+                        </subviews>
+                        <color key="backgroundColor" white="0.0" alpha="0.0" colorSpace="custom" customColorSpace="calibratedWhite"/>
+                        <constraints>
+                            <constraint firstItem="agd-bx-eW3" firstAttribute="centerY" secondItem="8bC-Xf-vdC" secondAttribute="centerY" id="Q2r-kQ-YnT"/>
+                            <constraint firstItem="agd-bx-eW3" firstAttribute="centerX" secondItem="8bC-Xf-vdC" secondAttribute="centerX" id="f2e-QG-cs7"/>
+                        </constraints>
+                    </view>
+                    <connections>
+                        <outlet property="mainView" destination="8bC-Xf-vdC" id="VrB-oe-Lkc"/>
+                    </connections>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/tvOSAppForTesting/Info.plist
+++ b/tvOSAppForTesting/Info.plist
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1</string>
+	<key>LSRequiresIPhoneOS</key>
+	<true/>
+	<key>UIMainStoryboardFile</key>
+	<string>Main</string>
+	<key>UIRequiredDeviceCapabilities</key>
+	<array>
+		<string>arm64</string>
+	</array>
+</dict>
+</plist>

--- a/tvOSAppForTesting/ViewController.swift
+++ b/tvOSAppForTesting/ViewController.swift
@@ -1,0 +1,35 @@
+//
+//  ViewController.swift
+//  tvOSAppForTesting
+//
+//  Created by Matthew Buckley on 10/21/15.
+//  Copyright © 2015 Bond. All rights reserved.
+//
+
+import UIKit
+import Bond
+
+class ViewController: UIViewController {
+
+  @IBOutlet var mainView: UIView!
+  let binary: Observable<Bool> = Observable(true)
+
+    override func viewDidLoad() {
+      super.viewDidLoad()
+
+      let timer = NSTimer(timeInterval: 1.0, target: self, selector: "update", userInfo: nil, repeats: true)
+      NSRunLoop.currentRunLoop().addTimer(timer, forMode: NSRunLoopCommonModes)
+
+      // Bind the background color
+      binary.observe({ value in
+        self.mainView.backgroundColor = value ? .greenColor() : .yellowColor()
+      })
+
+    }
+
+    func update() -> Void {
+      binary.value = !binary.value
+    }
+
+}
+


### PR DESCRIPTION
I implemented support for tvOS. Let me know if anything needs to change on this branch, happy to help in any way.  

- Added a new target and shared scheme for tvOS
- Selected source files to include (`UIRefreshControl`, `UIDatePicker`, `UISlider`, and `UISwitch` are not available for `tvOS`, so they are excluded)
- Added a new test project for `tvOS`
Note: all changes made using Xcode 7.1 beta 1

![oct 21 2015 23 58](https://cloud.githubusercontent.com/assets/2637355/10656770/607412a0-7850-11e5-9853-e6d6e9b086b0.gif)
