### PR TITLE
-> () to -> Void

### DIFF
--- a/Bond/Core/BindableType.swift
+++ b/Bond/Core/BindableType.swift
@@ -27,5 +27,5 @@ public protocol BindableType {
   
   /// Returns a sink that can be used to dispatch events to the receiver.
   /// Can accept a disposable that will be disposed on receiver's deinit.
-  func sink(disconnectDisposable: DisposableType?) -> (Element -> ())
+  func sink(disconnectDisposable: DisposableType?) -> (Element -> Void)
 }

--- a/Bond/Core/Buffer.swift
+++ b/Bond/Core/Buffer.swift
@@ -65,7 +65,7 @@ public struct Buffer<EventType> {
     }
   }
   
-  public func replayTo(sink: EventType -> ()) {
+  public func replayTo(sink: EventType -> Void) {
     for event in buffer {
       sink(event)
     }

--- a/Bond/Core/Disposable.swift
+++ b/Bond/Core/Disposable.swift
@@ -42,10 +42,10 @@ public final class BlockDisposable: DisposableType {
     return handler == nil
   }
   
-  private var handler: (() -> ())?
+  private var handler: (() -> Void)?
   private let lock = NSRecursiveLock(name: "com.swift-bond.Bond.BlockDisposable")
   
-  public init(_ handler: () -> ()) {
+  public init(_ handler: () -> Void) {
     self.handler = handler
   }
   

--- a/Bond/Core/EventProducer.swift
+++ b/Bond/Core/EventProducer.swift
@@ -39,7 +39,7 @@ public class EventProducer<Event>: EventProducerType {
   internal private(set) var replayBuffer: Buffer<Event>? = nil
   
   /// Type of the sink used by the event producer.
-  public typealias Sink = Event -> ()
+  public typealias Sink = Event -> Void
   
   /// Number of events to replay to each new observer.
   public var replayLength: Int {
@@ -108,7 +108,7 @@ public class EventProducer<Event>: EventProducerType {
   }
   
   /// Registers the given observer and returns a disposable that can cancel observing.
-  public func observe(observer: Event -> ()) -> DisposableType {
+  public func observe(observer: Event -> Void) -> DisposableType {
     
     if lifecycle == .Managed {
       selfReference?.retain()
@@ -167,7 +167,7 @@ extension EventProducer: BindableType {
   
   /// Creates a new sink that can be used to update the receiver.
   /// Optionally accepts a disposable that will be disposed on receiver's deinit.
-  public func sink(disconnectDisposable: DisposableType?) -> Event -> () {
+  public func sink(disconnectDisposable: DisposableType?) -> Event -> Void {
     
     if let disconnectDisposable = disconnectDisposable {
       deinitDisposable += disconnectDisposable

--- a/Bond/Core/EventProducerType.swift
+++ b/Bond/Core/EventProducerType.swift
@@ -41,7 +41,7 @@ public extension EventProducerType {
   
   /// Registers the observer that will receive only events generated after registering.
   /// A better performing verion of observable.skip(observable.replyLength).observe().
-  public func observeNew(observer: EventType -> ()) -> DisposableType {
+  public func observeNew(observer: EventType -> Void) -> DisposableType {
     var skip: Int = replayLength
     return observe { value in
       if skip > 0 {
@@ -154,7 +154,7 @@ public extension EventProducerType {
       var myEvent: EventType! = nil
       var itsEvent: U.EventType! = nil
       
-      let onBothNext = { () -> () in
+      let onBothNext = { () -> Void in
         if let myEvent = myEvent, let itsEvent = itsEvent {
           sink((myEvent, itsEvent))
         }

--- a/Bond/Core/ObservableArray.swift
+++ b/Bond/Core/ObservableArray.swift
@@ -74,7 +74,7 @@ public final class ObservableArray<ElementType>: EventProducer<ObservableArrayEv
   ///     numbers.append(2)
   ///     ...
   ///   }
-  public func performBatchUpdates(@noescape update: ObservableArray<ElementType> -> ()) {
+  public func performBatchUpdates(@noescape update: ObservableArray<ElementType> -> Void) {
     batchedOperations = []
     workingBatchArray = array
     update(self)

--- a/Bond/Core/Queue.swift
+++ b/Bond/Core/Queue.swift
@@ -40,16 +40,16 @@ public struct Queue {
     self.queue = queue
   }
   
-  public func after(interval: NSTimeInterval, block: () -> ()) {
+  public func after(interval: NSTimeInterval, block: () -> Void) {
     let dispatchTime = dispatch_time(DISPATCH_TIME_NOW, Int64(interval * NSTimeInterval(NSEC_PER_SEC)))
     dispatch_after(dispatchTime, queue, block)
   }
   
-  public func async(block: () -> ()) {
+  public func async(block: () -> Void) {
     dispatch_async(queue, block)
   }
 
-  public func sync(block: () -> ()) {
+  public func sync(block: () -> Void) {
     dispatch_sync(queue, block)
   }
 }

--- a/Bond/Extensions/OSX/NSControl+Bond.swift
+++ b/Bond/Extensions/OSX/NSControl+Bond.swift
@@ -27,9 +27,9 @@ import Cocoa
 @objc class NSControlBondHelper: NSObject
 {
   weak var control: NSControl?
-  let sink: AnyObject? -> ()
+  let sink: AnyObject? -> Void
   
-  init(control: NSControl, sink: AnyObject? -> ()) {
+  init(control: NSControl, sink: AnyObject? -> Void) {
     self.control = control
     self.sink = sink
     super.init()
@@ -63,7 +63,7 @@ extension NSControl {
     if let bnd_controlEvent: AnyObject = objc_getAssociatedObject(self, &AssociatedKeys.ControlEventKey) {
       return bnd_controlEvent as! EventProducer<AnyObject?>
     } else {
-      var capturedSink: (AnyObject? -> ())! = nil
+      var capturedSink: (AnyObject? -> Void)! = nil
       
       let bnd_controlEvent = EventProducer<AnyObject?> { sink in
         capturedSink = sink

--- a/Bond/Extensions/Shared/NSObject+Bond.swift
+++ b/Bond/Extensions/Shared/NSObject+Bond.swift
@@ -150,7 +150,7 @@ public extension NSObject {
     }
   }
   
-  public func bnd_associatedObservableForValueForKey<T>(key: String, initial: T? = nil, set: (T -> ())? = nil) -> Observable<T> {
+  public func bnd_associatedObservableForValueForKey<T>(key: String, initial: T? = nil, set: (T -> Void)? = nil) -> Observable<T> {
     if let observable: AnyObject = bnd_associatedObservables[key] {
       return observable as! Observable<T>
     } else {
@@ -174,7 +174,7 @@ public extension NSObject {
     }
   }
   
-  public func bnd_associatedObservableForValueForKey<T: OptionalType>(key: String, initial: T? = nil, set: (T -> ())? = nil) -> Observable<T> {
+  public func bnd_associatedObservableForValueForKey<T: OptionalType>(key: String, initial: T? = nil, set: (T -> Void)? = nil) -> Observable<T> {
     if let observable: AnyObject = bnd_associatedObservables[key] {
       return observable as! Observable<T>
     } else {

--- a/Bond/Extensions/iOS/UIControl+Bond.swift
+++ b/Bond/Extensions/iOS/UIControl+Bond.swift
@@ -27,9 +27,9 @@ import UIKit
 @objc class UIControlBondHelper: NSObject
 {
   weak var control: UIControl?
-  let sink: UIControlEvents -> ()
+  let sink: UIControlEvents -> Void
   
-  init(control: UIControl, sink: UIControlEvents -> ()) {
+  init(control: UIControl, sink: UIControlEvents -> Void) {
     self.control = control
     self.sink = sink
     super.init()
@@ -121,7 +121,7 @@ extension UIControl {
     if let bnd_controlEvent: AnyObject = objc_getAssociatedObject(self, &AssociatedKeys.ControlEventKey) {
       return bnd_controlEvent as! EventProducer<UIControlEvents>
     } else {
-      var capturedSink: (UIControlEvents -> ())! = nil
+      var capturedSink: (UIControlEvents -> Void)! = nil
       
       let bnd_controlEvent = EventProducer<UIControlEvents> { sink in
         capturedSink = sink

--- a/BondTests/EventProducerTests.swift
+++ b/BondTests/EventProducerTests.swift
@@ -44,7 +44,7 @@ class ObservableTests: XCTestCase {
   
   func testObservingAndDisposingObserver() {
     var observedValue = -1
-    var capturedSink: (Int -> ())!
+    var capturedSink: (Int -> Void)!
     
     let eventProducer = EventProducer<Int> { sink in
       capturedSink = sink
@@ -151,7 +151,7 @@ class ObservableTests: XCTestCase {
   }
   
   func testNormalLifecycleDoesNotCauseSinkToRetainObservableWhenThereIsAnObserver() {
-    var capturedSink: (Int -> ())!
+    var capturedSink: (Int -> Void)!
     var eventProducer: EventProducer<Int>! = EventProducer(lifecycle: .Normal) { sink in
       capturedSink = sink
       return nil

--- a/BondTests/ObservableTests.swift
+++ b/BondTests/ObservableTests.swift
@@ -95,7 +95,7 @@ class ObservableValueTests: XCTestCase {
     weak var observableWeak: Observable<Int>! = observable
     let disposable = SimpleDisposable()
     
-    let sink: (Int -> ())? = observable.sink(disposable)
+    let sink: (Int -> Void)? = observable.sink(disposable)
     
     XCTAssert(sink != nil)
     XCTAssertNotNil(observableWeak)

--- a/README.md
+++ b/README.md
@@ -149,7 +149,7 @@ print(captain.value) // prints: Spock
 
 The property is both a getter that returns the observable’s value and a setter that updates the observable with a new value just like the method `next`.
 
-Now comes the interesting part. In order to make the observable useful it should be observed. Observing the observable means observing the events it generates, that is, in our case, the values that are being set. To observe the observable we register a closure of the type `EventType -> ()` to it with the method observe, where *EventType* is the event (value) type:
+Now comes the interesting part. In order to make the observable useful it should be observed. Observing the observable means observing the events it generates, that is, in our case, the values that are being set. To observe the observable we register a closure of the type `EventType -> Void` to it with the method observe, where *EventType* is the event (value) type:
 
 ```swift
 captain.observe { name in
@@ -178,7 +178,7 @@ captain.value = “Scotty” // prints: Now the captain is Scotty.
 Using the observable that acts as a variable or a property that can be observed is just a specific usage of the EventProducer. As was already said, the event producer represents an abstract event generator. To create such event generator you can use the following designated initializer on EventProducer:
 
 ```swift
-init(replayLength: Int, @noescape producer: (EventType -> ()) -> DisposableType?)
+init(replayLength: Int, @noescape producer: (EventType -> Void) -> DisposableType?)
 ```
 
 Parameter `replayLength` defines how many events should be replayed to each new observer. It represents the memory of the event producer. Event producers don't have to have memory so zero is a valid value for this parameter. Event producers without a memory are used to represent actions, something without a state, like button taps.
@@ -190,7 +190,7 @@ Parameter `producer` is a closure that actually generates events. The closure ac
 An event producer (and so observable) can be observed by any number of observers. A new observer is registered with the already mentioned `observe` method. Here is its signature:
 
 ```swift
-func observe(observer: EventType -> ()) -> DisposableType
+func observe(observer: EventType -> Void) -> DisposableType
 ```
 
 We've already talked about the closure parameter `observer`, but it is also important to understand what the method returns. An observer stays registered until it’s unregistered or until the event producer is destroyed. To unregistered the observer manually we use a disposable object returned by the method `observe`. Think of it as a subscription that can be cancelled. To cancel it simply use the method `dispose`.


### PR DESCRIPTION
improve readability.

word of Apple at
devforums（https://devforums.apple.com/message/1133616）:

“FWIW, we’ve recently decided to standardize on () -> Void (generally,
() for parameters and Void for return types) across all of our
documentation.”