### PR TITLE
Improve Travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,9 @@ xcode_project: Bond.xcodeproj
 xcode_scheme: Bond
 osx_image: xcode7
 
-script: xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test && xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test
+script: 
+  - xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test 
+  - xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ osx_image: xcode7
 script: 
   - xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test 
   - xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test
+  - xcodebuild -project Bond.xcodeproj -scheme BondtvOS -sdk appletvos build
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ install:
 script:
   - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test | xcpretty
   - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test | xcpretty
-  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondtvOS -sdk appletvos build | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 language: objective-c
-xcode_project: Bond.xcodeproj
-xcode_scheme: Bond
 osx_image: xcode7
 
 script: 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,13 @@
 language: objective-c
 osx_image: xcode7
 
-script: 
-  - xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test 
-  - xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test
-  - xcodebuild -project Bond.xcodeproj -scheme BondtvOS -sdk appletvos build
+install:
+  - gem install xcpretty
+
+script:
+  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme Bond -sdk iphonesimulator -destination 'platform=iOS Simulator,name=iPhone 6,OS=9.0' test | xcpretty
+  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondOSX -sdk macosx test | xcpretty
+  - set -o pipefail && xcodebuild -project Bond.xcodeproj -scheme BondtvOS -sdk appletvos build | xcpretty
 
 after_success:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: objective-c
-osx_image: xcode7
+osx_image: xcode7.1
 
 install:
   - gem install xcpretty


### PR DESCRIPTION
Some improvements can be made to Travis config:
- [x] Test failures can be accumulated, so that it is easier to see what else is broken
- [x] Xcode-related fields can be removed as we do custom build steps
- [x] Use `xcpretty` to format output 