### PR TITLE
Add tableView reload option in BNDTableViewProxyDataSource

### DIFF
--- a/Bond/Extensions/iOS/UITableView+Bond.swift
+++ b/Bond/Extensions/iOS/UITableView+Bond.swift
@@ -65,7 +65,7 @@ private class BNDTableViewDataSource<T>: NSObject, UITableViewDataSource {
     
     array.observeNew { [weak self] arrayEvent in
       guard let unwrappedSelf = self, let tableView = unwrappedSelf.tableView else { return }
-      if let _ = unwrappedSelf.proxyDataSource?.shouldReloadInsteadOfUpdateTableView?(tableView) { tableView.reloadData(); return }
+      if let reload = unwrappedSelf.proxyDataSource?.shouldReloadInsteadOfUpdateTableView?(tableView) where reload { tableView.reloadData(); return }
       
       switch arrayEvent.operation {
       case .Batch(let operations):
@@ -90,7 +90,7 @@ private class BNDTableViewDataSource<T>: NSObject, UITableViewDataSource {
     for (sectionIndex, sectionObservableArray) in array.enumerate() {
       sectionObservableArray.observeNew { [weak tableView, weak self] arrayEvent in
         guard let tableView = tableView else { return }
-        if let _ = self?.proxyDataSource?.shouldReloadInsteadOfUpdateTableView?(tableView) { tableView.reloadData(); return }
+        if let reload = self?.proxyDataSource?.shouldReloadInsteadOfUpdateTableView?(tableView) where reload { tableView.reloadData(); return }
         
         switch arrayEvent.operation {
         case .Batch(let operations):

--- a/Bond/Extensions/iOS/UITableView+Bond.swift
+++ b/Bond/Extensions/iOS/UITableView+Bond.swift
@@ -101,10 +101,7 @@ private class BNDTableViewDataSource<T>: NSObject, UITableViewDataSource {
           tableView.endUpdates()
         case .Reset:
           let indices = Set([sectionIndex])
-          if let animation = self?.proxyDataSource?.tableView?(tableView, shouldAnimationForRowInSections: indices) where animation == false {
-            tableView.reloadData()
-            break
-          }
+          if let animation = self?.proxyDataSource?.tableView?(tableView, shouldAnimationForRowInSections: indices) where animation == false { tableView.reloadData(); break }
           tableView.reloadSections(NSIndexSet(index: sectionIndex), withRowAnimation: self?.proxyDataSource?.tableView?(tableView, animationForRowInSections: indices) ?? .Automatic)
         default:
           BNDTableViewDataSource.applyRowUnitChangeSet(arrayEvent.operation.changeSet(), tableView: tableView, sectionIndex: sectionIndex, dataSource: self?.proxyDataSource)


### PR DESCRIPTION
close https://github.com/SwiftBond/Bond/issues/209

I add should animation method to `BNDTableViewProxyDataSource` because I need to insert, delete or update without animation.

UITableViewRowAnimation.None doesn't prevent row animation.

The result is this:

![no-animation](https://cloud.githubusercontent.com/assets/536954/11452866/58cdaf8c-9639-11e5-8acc-3a80c52d8310.gif)

I closed https://github.com/SwiftBond/Bond/pull/210 because it ignore UITableViewRowAnimation.None's nature.