### PR TITLE
Add debounce

### DIFF
--- a/Bond/Core/EventProducerType.swift
+++ b/Bond/Core/EventProducerType.swift
@@ -123,7 +123,23 @@ public extension EventProducerType {
       }
     }
   }
-  
+
+  /// Throttles event dispatching for a given number of seconds after dispatches first event.
+  public func debounce(seconds: Queue.TimeInterval, queue: Queue) -> EventProducer<EventType> {
+    return EventProducer(replayLength: replayLength) { sink in
+      var firstEvent: EventType! = nil
+      return observe { event in
+        if firstEvent == nil {
+          firstEvent = event
+          sink(firstEvent)
+          queue.after(seconds) {
+            firstEvent = nil
+          }
+        }
+      }
+    }
+  }
+
   /// Ignores first `count` events and forwards any subsequent.
   public func skip(count: Int) -> EventProducer<EventType> {
     var internalCount = count

--- a/README.md
+++ b/README.md
@@ -237,6 +237,14 @@ func throttle(seconds: Queue.TimeInterval, queue: Queue) -> EventProducer<EventT
 
 Creates an event producer that forwards no more than one event in the given number of seconds.
 
+#### Debounce
+
+```swift
+func debounce(seconds: Queue.TimeInterval, queue: Queue) -> EventProducer<EventType>
+```
+
+Creates an event producer that ignores events which are followed by another event within the given number of seconds.
+
 #### Skip
 
 ```swift


### PR DESCRIPTION
add debounce to EventProducerType
http://reactivex.io/documentation/operators/debounce.html

"debounce" is useful to ignore repeated touches.
```
    shutterButton.bnd_controlEvent
        .filter { $0 == .TouchDown }
        .debounce(2, queue: Queue())
        .observeNew { [unowned self] _ in
          // do something
    }
```
