### PR TITLE
Fix index bug in append method

### DIFF
--- a/Sources/ObservableArray.swift
+++ b/Sources/ObservableArray.swift
@@ -101,7 +101,7 @@ public class MutableObservableArray<Item>: ObservableArray<Item> {
   public func append(_ newElement: Item) {
     lock.atomic {
       array.append(newElement)
-      subject.next(ObservableArrayEvent(change: .inserts([array.count]), source: self))
+      subject.next(ObservableArrayEvent(change: .inserts([array.count-1]), source: self))
     }
   }
   


### PR DESCRIPTION
The event with insertion on append should have as index the last index (i.e. count-1), right?